### PR TITLE
Use single = in [ ] test

### DIFF
--- a/common/bin/ceylon
+++ b/common/bin/ceylon
@@ -16,7 +16,7 @@ DIR=$(dirname "$PRG")
 
 CEYLON_HOME="$DIR/.."
 
-if [ "$1" == "--show-home" ]; then
+if [ "$1" = "--show-home" ]; then
     echo "$CEYLON_HOME"
     exit
 fi


### PR DESCRIPTION
Per [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html), the `test(1)` command performs string comparison with a single equals sign:

```
s1 = s2
```

Bash's builtin `[` and the coreutils version both also support the double
equals sign, but Dash, the default `/bin/sh` on Debian-based systems, does
not. For this reason, the command to test for the `--print-cwd` option
would fail on Debian-based systems with an error like this:

```
.../ceylon: 19: [: --cwd=...: unexpected operator
```

To fix this, use a single equals sign.
