### PR TITLE
Make the README.eclipse file more complete.

### DIFF
--- a/README.eclipse
+++ b/README.eclipse
@@ -1,32 +1,64 @@
 Setting up Eclipse to build the Ceylon compiler
 ===============================================
 
-First make sure you have compiled the ceylon projects according to the instruction in the README.md file!
-
 Global Eclipse configuration:
 
  i.  Set your default "Text file encoding" to "UTF-8" and your default "New text file line delimiter"
      to "Unix" in your Eclipse preferences (Window -> Preferences -> General -> Workspace). If you do
-     this you can skip Step 6 below.
+     this you can skip Step 1 in "Post-import steps" below.
+     (N.B. these should already be the default settings on Linux.)
 
  ii. Go to the preferences of the installed JREs (Window -> Preferebces -> Java -> Installed JREs) and
      select the active JRE and click "Edit". In the popup type "-ea" in the "Default VM arguments" field.
      Then click "Finish" and "Ok". (Repeat this for any JREs you intend to use with Ceylon)
 
-Importing the Ceylon projects:
+N.B. in this file, "/path/to/ceylon" should be replaced with the full path of the directory containing
+this file.
 
- 1. NB, in this file, "/path/to/ceylon" should be replaced with the
-    full path of the directory containing this file.
 
- 2. Select "File -> Import..." from the main menu.
+** Option 1: Importing the Ceylon projects directly from git:
 
- 3. In the "Import" dialog:
+ 1. Ensure you have egit installed in Eclipse: go to Help -> About Eclipse -> Installation Details.
+
+    a) If "Eclipse Git Team Provider" is not listed, go to Help -> Install New Software, and enter
+       the following into "Work with":
+
+        http://download.eclipse.org/egit/updates
+
+    b) Select and install "Eclipse Git Team Provider", and restart Eclipse when prompted.
+
+ 2. Clone the git repo.
+ 
+    a) Select File -> Import -> Git -> Projects from Git -> Clone URI.
+
+    b) Enter into the URI field:
+
+       https://github.com/ceylon/ceylon.git
+
+    c) In the "Branch selection" dialog, click "Deselect All", then select "master".
+
+    d) Click "Next >", choose a location for the project, and click "Next >" again. The repo will be cloned.
+
+    e) Select "Wizard for project import -> Import existing Eclipse projects" and "Working Tree", then "Next >".
+
+    f) In the "Import Projects" list, deselect everything that starts with a "@" and everything that starts
+       with "ceylon-dist-osgi".
+
+    g) Click "Finish". You will see some errors on the imported projects until you complete "Initial build"
+       below.
+
+
+** Option 2: Importing the Ceylon projects from disk, after following the instructions in the README.md:
+
+ 1. Select "File -> Import..." from the main menu.
+
+ 2. In the "Import" dialog:
 
     a) Select "General -> Existing Projects into Workspace"
 
     c) Click "Next >"
 
- 4. In the next page of the "Import" dialog:
+ 3. In the next page of the "Import" dialog:
 
     a) Make sure the "Select root directory" is selected
 
@@ -36,15 +68,21 @@ Importing the Ceylon projects:
 
     d) Click "Ok"
 
- 5. Back in the Wizard dialog:
+ 4. Back in the Wizard dialog:
 
     a) In the "Options" section enable "Search for nested projects"
 
-    b) In the "Projects" list deselect everything that starts with a "@" and everything that starts with "ceylon-dist-osgi"
+    b) In the "Projects" list deselect everything that starts with a "@" and everything that starts with
+       "ceylon-dist-osgi"
 
-    c) Click "Finish"
+    c) Click "Finish". You will see some errors on the imported projects until you complete "Initial build"
+       below.
 
- 6. If you didn't apply the setting of Step 0 you now have to set them in the properties for each of the imported projects:
+
+** Post-import steps:
+
+ 1. If you didn't apply the settings described in "Global eclipse configuration" step "i.", you now have to
+    apply these settings in the properties for each of the imported projects:
 
     a) Right-click on the project, select Properties then Resource
     
@@ -54,7 +92,7 @@ Importing the Ceylon projects:
     
     d) Click "Ok"
 
- 7. If you see an error of the form
+ 2. If you see an error of the form
 
     "Access restriction: Class is not accessible due to restriction on
     required library"
@@ -67,11 +105,32 @@ Importing the Ceylon projects:
     "Deprecated and restricted API" section in the dialog box.  Set
     this to Warning" or "Ignore".
 
- 8. The project should now be correctly set up.  To test it:
 
- 9. Select "Run -> Run Configurations..." from the main menu.
+** Initial build:
 
-10. In the "Run Configurations" dialog:
+You need to build once with Ant before Eclipse can successfully build the projects.
+
+(The following assumes your version of Eclipse has Ant installed, which it should by default.)
+
+ 1. In Package Explorer, open up the tree view for the "ceylon" project, right-click on "build.xml", and
+    select "Run As -> Ant Build...".
+
+ 2. Deselect all targets except for "clean" and "dist", then click on "Order...", and make sure "clean"
+    is listed above "dist". Click "OK".
+ 
+ 3. Back in the "Run As -> Ant Build... -> Edit Configuration" dialog, click "Run".
+
+ 4. Once Ceylon has finished building, in the Package Explorer, select all projects (Ctrl+A) and then Refresh
+    (F5, or right-click -> Refresh).
+
+ 5. You should see the errors on the projects disappear.
+
+
+** The project should now be correctly set up. To test it:
+ 
+ 1. Select "Run -> Run Configurations..." from the main menu.
+
+ 2. In the "Run Configurations" dialog:
 
     a) Right click on "JUnit" in the list on the left
        and select "New" from the popup menu.
@@ -88,7 +147,7 @@ Importing the Ceylon projects:
 
        ii) Click "Ok"
 
-    f) In the "Test class" line, select "Search...":
+    f) In the "Test class" line, select "Search..." (it may take several seconds for the next dialog to pop up):
  
        i) Select "ConcurrentTests"
  
@@ -96,7 +155,5 @@ Importing the Ceylon projects:
  
     g) Click "Run"
 
-11. You should see some output from the Ceylon compiler in the
-    "Console" tab at the bottom of the screen. Some tests will fail
-    but most should succeed.
-
+ 3. You should see some output from the Ceylon compiler in the "Console" tab at the bottom of the screen.
+    Some tests will fail but most should succeed.


### PR DESCRIPTION
This PR includes instructions for fetching the projects using egit, and building using the version of Ant that is built into Eclipse.
