### PR TITLE
register dart backend

### DIFF
--- a/common/src/com/redhat/ceylon/common/Backend.java
+++ b/common/src/com/redhat/ceylon/common/Backend.java
@@ -17,6 +17,7 @@ public class Backend {
         Header = createBackend("Header", "");
         Java = registerBackend("Java", "jvm");
         JavaScript = registerBackend("JavaScript", "js");
+        registerBackend("Dart", "dart");
     }
     
     public final String name;


### PR DESCRIPTION
With this commit, the "dart" backend will be always be registered, avoiding errors like:

```
error: illegal native backend name: '"dart"' (must be either '"jvm"' or '"js"')
```

when attempting to `compile` or `compile-js` a dart backend enabled project. (Maintaining separate source code branches for Dart enabled modules is inconvenient.)

There are other open issues and discussions for ways to support additional backends, but this PR seems to be the most practical approach at the moment.
