### PR TITLE
don't include Dart in supported backends

### DIFF
--- a/compiler-java/src/com/redhat/ceylon/ceylondoc/CeylonDocModuleManager.java
+++ b/compiler-java/src/com/redhat/ceylon/ceylondoc/CeylonDocModuleManager.java
@@ -160,9 +160,6 @@ public class CeylonDocModuleManager extends ReflectionModuleManager {
         // This is most likely not the correct solution but it
         // still works for all current cases and allows generating
         // docs for non-JVM modules at the same time
-        return Backends.ANY
-                .merged(Backend.Header)
-                .merged(Backend.Java)
-                .merged(Backend.JavaScript);
+        return Backends.JAVA.merged(Backend.JavaScript);
     }
 }

--- a/compiler-java/src/com/redhat/ceylon/ceylondoc/CeylonDocModuleManager.java
+++ b/compiler-java/src/com/redhat/ceylon/ceylondoc/CeylonDocModuleManager.java
@@ -160,6 +160,9 @@ public class CeylonDocModuleManager extends ReflectionModuleManager {
         // This is most likely not the correct solution but it
         // still works for all current cases and allows generating
         // docs for non-JVM modules at the same time
-        return Backend.getRegisteredBackends();
+        return Backends.ANY
+                .merged(Backend.Header)
+                .merged(Backend.Java)
+                .merged(Backend.JavaScript);
     }
 }


### PR DESCRIPTION
> This prevents 'ceylon doc' from attempting to load 'native("dart")'
> imports.

This patch seems to work. Not sure if we need to pre-calculate/memoize the instance of `Backends`.
