### PR TITLE
support constructors in static member classes; fix #6011

### DIFF
--- a/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
+++ b/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
@@ -6603,6 +6603,10 @@ public class ExpressionVisitor extends Visitor {
                     Tree.QualifiedMemberOrTypeExpression qmte = 
                             (Tree.QualifiedMemberOrTypeExpression) 
                                 primary;
+                    if (qmte.getDeclaration()
+                            .isStaticallyImportable()) {
+                        return type;
+                    }
                     Tree.MemberOrTypeExpression pp = 
                             (Tree.MemberOrTypeExpression) 
                                 qmte.getPrimary();


### PR DESCRIPTION
With this patch, it's possible to invoke and take references to
constructors of static member classes. For invocations, type argument
inference works. These operations also work when using an import alias
for the static member class when qualifying the constructor.

@gavinking it looks like this is all that is needed. And if not, it's hard to see that this would do actual harm; `isStaticallyImportable` should always be false for classes with constructors on the JS and JVM backends.

It would be really nice to have this for the upcoming patch release.
