### PR TITLE
initialize JsonPackage lazily, don't eagerly resolve modules

### DIFF
--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsModuleSourceMapper.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsModuleSourceMapper.java
@@ -77,19 +77,6 @@ public class JsModuleSourceMapper extends ModuleSourceMapper {
             model.remove("$mod-deps");
         }
         ((JsonModule)module).setModel(model);
-        for (ModuleImport imp : module.getImports()) {
-            if (!imp.getModule().getNameAsString().equals(Module.LANGUAGE_MODULE_NAME)) {
-                ArtifactContext ac = new ArtifactContext(imp.getModule().getNameAsString(),
-                        imp.getModule().getVersion(), ArtifactContext.JS_MODEL);
-                artifact = getContext().getRepositoryManager().getArtifactResult(ac);
-                if (artifact == null) {
-                    throw new IllegalStateException("No model for " + imp.getModule());
-                } else {
-                    resolveModule(artifact, imp.getModule(), imp, dependencyTree,
-                            phasedUnitsOfDependencies, forCompiledModule & imp.isExport());
-                }
-            }
-        }
         ((JsonModule)module).loadDeclarations();
         return;
     }

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonModule.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonModule.java
@@ -69,9 +69,6 @@ public class JsonModule extends Module {
                         getPackages().add(p);
                     }
                 }
-                for (JsonPackage p : pks) {
-                    p.loadDeclarations();
-                }
             }
         }
     }

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/LazyPackage.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/LazyPackage.java
@@ -1,0 +1,201 @@
+package com.redhat.ceylon.compiler.js.loader;
+
+import java.util.List;
+import java.util.Map;
+
+import com.redhat.ceylon.common.Backends;
+import com.redhat.ceylon.model.typechecker.model.Annotation;
+import com.redhat.ceylon.model.typechecker.model.Cancellable;
+import com.redhat.ceylon.model.typechecker.model.Declaration;
+import com.redhat.ceylon.model.typechecker.model.DeclarationWithProximity;
+import com.redhat.ceylon.model.typechecker.model.Import;
+import com.redhat.ceylon.model.typechecker.model.Module;
+import com.redhat.ceylon.model.typechecker.model.Package;
+import com.redhat.ceylon.model.typechecker.model.Scope;
+import com.redhat.ceylon.model.typechecker.model.Type;
+import com.redhat.ceylon.model.typechecker.model.TypeDeclaration;
+import com.redhat.ceylon.model.typechecker.model.Unit;
+
+public abstract class LazyPackage extends Package {
+
+    protected abstract void loadIfNecessary();
+
+    @Override
+    public boolean isToplevel() {
+        loadIfNecessary();
+        return super.isToplevel();
+    }
+
+    @Override
+    public Module getModule() {
+        // not lazy
+        return super.getModule();
+    }
+
+    @Override
+    public void setModule(Module module) {
+        super.setModule(module);
+    }
+
+    @Override
+    public List<String> getName() {
+        // not lazy
+        return super.getName();
+    }
+
+    @Override
+    public void setName(List<String> name) {
+        super.setName(name);
+    }
+
+    @Override
+    public Iterable<Unit> getUnits() {
+        loadIfNecessary();
+        return super.getUnits();
+    }
+
+    @Override
+    public boolean isShared() {
+        loadIfNecessary();
+        return super.isShared();
+    }
+
+    @Override
+    public void setShared(boolean shared) {
+        super.setShared(shared);
+    }
+
+    @Override
+    public List<Declaration> getMembers() {
+        loadIfNecessary();
+        return super.getMembers();
+    }
+
+    @Override
+    public Scope getContainer() {
+        loadIfNecessary();
+        return super.getContainer();
+    }
+
+    @Override
+    public Scope getScope() {
+        loadIfNecessary();
+        return super.getScope();
+    }
+
+    @Override
+    public String getNameAsString() {
+        // not lazy
+        return super.getNameAsString();
+    }
+
+    @Override
+    public String toString() {
+        loadIfNecessary();
+        return super.toString();
+    }
+
+    @Override
+    public String getQualifiedNameString() {
+        // not lazy
+        return super.getQualifiedNameString();
+    }
+
+    @Override
+    public Declaration getMember(String name, List<Type> signature, boolean variadic) {
+        loadIfNecessary();
+        return super.getMember(name, signature, variadic);
+    }
+
+    @Override
+    public Declaration getDirectMember(String name, List<Type> signature, boolean variadic) {
+        loadIfNecessary();
+        return super.getDirectMember(name, signature, variadic);
+    }
+
+    @Override
+    public Declaration getDirectMemberForBackend(String name, Backends backends) {
+        loadIfNecessary();
+        return super.getDirectMemberForBackend(name, backends);
+    }
+
+    @Override
+    public Type getDeclaringType(Declaration d) {
+        loadIfNecessary();
+        return super.getDeclaringType(d);
+    }
+
+    @Override
+    public Declaration getMemberOrParameter(Unit unit, String name, List<Type> signature, boolean variadic) {
+        loadIfNecessary();
+        return super.getMemberOrParameter(unit, name, signature, variadic);
+    }
+
+    @Override
+    public boolean isInherited(Declaration d) {
+        loadIfNecessary();
+        return super.isInherited(d);
+    }
+
+    @Override
+    public TypeDeclaration getInheritingDeclaration(Declaration d) {
+        loadIfNecessary();
+        return super.getInheritingDeclaration(d);
+    }
+
+    @Override
+    public Map<String, DeclarationWithProximity> getMatchingDeclarations(Unit unit,
+            String startingWith, int proximity, Cancellable canceller) {
+        loadIfNecessary();
+        return super.getMatchingDeclarations(unit, startingWith, proximity, canceller);
+    }
+
+    @Override
+    public Map<String, DeclarationWithProximity> getMatchingDirectDeclarations(
+            String startingWith, int proximity) {
+        loadIfNecessary();
+        return super.getMatchingDirectDeclarations(startingWith, proximity);
+    }
+
+    @Override
+    public Map<String, DeclarationWithProximity> getImportableDeclarations(
+            Unit unit, String startingWith, List<Import> imports, int proximity) {
+        loadIfNecessary();
+        return super.getImportableDeclarations(unit, startingWith, imports, proximity);
+    }
+
+    @Override
+    public List<Annotation> getAnnotations() {
+        // not lazy
+        return super.getAnnotations();
+    }
+
+    @Override
+    public int hashCode() {
+        loadIfNecessary();
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        loadIfNecessary();
+        return super.equals(obj);
+    }
+
+    @Override
+    public Unit getUnit() {
+        loadIfNecessary();
+        return super.getUnit();
+    }
+
+    @Override
+    public void setUnit(Unit unit) {
+        super.setUnit(unit);
+    }
+
+    @Override
+    public Backends getScopedBackends() {
+        loadIfNecessary();
+        return super.getScopedBackends();
+    }
+}

--- a/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/ModuleValidator.java
+++ b/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/ModuleValidator.java
@@ -212,7 +212,7 @@ public class ModuleValidator {
             Module module = moduleImport.getModule();
             if (moduleManager.findModule(module, dependencyTree, true) != null) {
                 //circular dependency: stop right here
-                return;
+                continue;
             }
             Iterable<String> searchedArtifactExtensions = moduleManager.getSearchedArtifactExtensions();
             ImportDepth newImportDepth = importDepth.forModuleImport(moduleImport);


### PR DESCRIPTION
Previously:
1. When loading a module, imports were eagerly resolved and loaded
2. When loading a module, declarations were eagerly loaded for all
   packages.

This patch adds LazyPackage, allowing #2 to be delayed, which in turn
allows #1 to be skipped (it's ok, the typechecker will eventually
request all necessary modules to be loaded.)

The result is support for the following compile time scenarios:
1. Import of modules with circular dependencies (#6003)
2. Import of a module that depends on a module currently being compiled
   (a normally impossible scenario, but may be useful in some cases,
   such as compiling a language module that depends on an interop
   module that depends on the language module.)
3. The bizarre scenario of compiling a module that imports a module that
   is not currenlty being compiled that imports a third module that is
   currently being compiled (#5976)

This patch fixes #5976 and fixes the compile-time component of #6003.
