### PR TITLE
Support instantiating TypeScript classes with new

### DIFF
--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/InvocationGenerator.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/InvocationGenerator.java
@@ -93,6 +93,7 @@ public class InvocationGenerator {
         } else {
             gen.out("(");
             Map<String, String> argVarNames = defineNamedArguments(typeArgSource, argList);
+            writeNew(typeArgSource);
             if (typeArgSource instanceof Tree.BaseMemberExpression) {
                 BmeGenerator.generateBme((Tree.BaseMemberExpression)typeArgSource, gen);
             } else if (typeArgSource instanceof Tree.QualifiedTypeExpression) {
@@ -142,6 +143,7 @@ public class InvocationGenerator {
             //TODO we lose type args for now
             return;
         } else {
+            writeNew(typeArgSource);
             if (typeArgSource instanceof Tree.BaseMemberExpression) {
                 final Tree.BaseMemberExpression _bme = (Tree.BaseMemberExpression)typeArgSource;
                 if (gen.isInDynamicBlock() && _bme.getDeclaration() != null &&
@@ -703,6 +705,22 @@ public class InvocationGenerator {
             gen.out("[]");
         } else {
             TypeUtils.encodeParameterListForRuntime(true, term, plist, gen);
+        }
+    }
+
+    /**
+     * Emit {@code new} if the invoked function should be invoked with {@code new}.
+     * @see Functional#isJsNew()
+     */
+    void writeNew(Tree.Primary invoked) {
+        if (invoked instanceof Tree.BaseTypeExpression) {
+            Tree.BaseTypeExpression bte = (Tree.BaseTypeExpression)invoked;
+            if (bte.getDeclaration() instanceof Functional) {
+                Functional f = (Functional)bte.getDeclaration();
+                if (f.isJsNew()) {
+                    gen.out("new ");
+                }
+            }
         }
     }
 

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
@@ -234,6 +234,9 @@ public class JsonPackage extends LazyPackage {
                 cnst.setScope(cls);
                 cnst.setUnit(cls.getUnit());
                 cnst.setExtendedType(cls.getType());
+                if (cons.getValue().containsKey(MetamodelGenerator.KEY_JS_NEW)) {
+                    cnst.setJsNew((Boolean)cons.getValue().remove(MetamodelGenerator.KEY_JS_NEW));
+                }
                 setAnnotations(cnst, (Integer)cons.getValue().remove(MetamodelGenerator.KEY_PACKED_ANNS),
                         (Map<String,Object>)cons.getValue().remove(MetamodelGenerator.KEY_ANNOTATIONS));
                 final List<Map<String,Object>> modelPlist = (List<Map<String,Object>>)cons.getValue().remove(
@@ -268,6 +271,7 @@ public class JsonPackage extends LazyPackage {
                     cf.setVisibleScope(cnst.getVisibleScope());
                     cf.setShared(cnst.isShared());
                     cf.setDeprecated(cnst.isDeprecated());
+                    cf.setJsNew(cnst.isJsNew());
                     cls.addMember(cf);
                 }
             }

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/MetamodelGenerator.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/MetamodelGenerator.java
@@ -63,6 +63,9 @@ public class MetamodelGenerator {
     public static final String KEY_DEFAULT      = "def";
     public static final String KEY_DYNAMIC      = "dyn";
 
+    // backend specific keys
+    public static final String KEY_JS_NEW       = "$new"; // should be instantiated with new; TypeScript interop
+
     public static final String METATYPE_CLASS           = "c";
     public static final String METATYPE_INTERFACE       = "i";
     public static final String METATYPE_ALIAS           = "als";

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Class.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Class.java
@@ -225,6 +225,18 @@ public class Class extends ClassOrInterface implements Functional {
     	return (flags&OVERLOADED)!=0;
     }
     
+    @Override
+    public boolean isJsNew() {
+        if (hasConstructors()) {
+            Constructor defaultConstructor = 
+                    getDefaultConstructor();
+            return defaultConstructor!=null &&
+                    defaultConstructor.isJsNew();
+        } else {
+            return false;
+        }
+    }
+    
     public void setOverloaded(boolean overloaded) {
         if (overloaded) {
             flags|=OVERLOADED;

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Constructor.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Constructor.java
@@ -18,6 +18,7 @@ public class Constructor extends TypeDeclaration implements Functional {
     private static final int ABSTRACT = 1<<13;
     private static final int OVERLOADED = 1<<19;
     private static final int ABSTRACTION = 1<<20;
+    private static final int JS_NEW = 1<<25;
     
     private ParameterList parameterList;
     private List<Declaration> overloads;
@@ -93,6 +94,20 @@ public class Constructor extends TypeDeclaration implements Functional {
     @Override
     public boolean isAbstraction() {
         return (flags&ABSTRACTION)!=0;
+    }
+    
+    @Override
+    public boolean isJsNew() {
+        return (flags&JS_NEW)!=0;
+    }
+    
+    public void setJsNew(boolean $new) {
+        if ($new) {
+            flags|=JS_NEW;
+        }
+        else {
+            flags&=(~JS_NEW);
+        }
     }
     
     @Override

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Function.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Function.java
@@ -18,6 +18,7 @@ public class Function extends FunctionOrValue implements Generic, Scope, Functio
     private static final int VOID = 1<<22;
     private static final int DEFERRED = 1<<23;
     private static final int NO_NAME = 1<<24;
+    private static final int JS_NEW = 1<<25;
     
     private List<TypeParameter> typeParameters = emptyList();
     private List<ParameterList> parameterLists = new ArrayList<ParameterList>(1);
@@ -124,6 +125,20 @@ public class Function extends FunctionOrValue implements Generic, Scope, Functio
         return (flags&NO_NAME)==0;
     }
 
+    @Override
+    public boolean isJsNew() {
+        return (flags&JS_NEW)!=0;
+    }
+    
+    public void setJsNew(boolean $new) {
+        if ($new) {
+            flags|=JS_NEW;
+        }
+        else {
+            flags&=(~JS_NEW);
+        }
+    }
+    
     @Override
     public Backends getScopedBackends() {
         return super.getScopedBackends();

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Functional.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Functional.java
@@ -25,5 +25,11 @@ public interface Functional {
 //    public List<TypeParameter> getTypeParameters();
     
     public boolean isDeclaredVoid();
+    /**
+     * Returns {@code true} if this is a constructor that should,
+     * on the JavaScript backend,
+     * be instantiated with {@code new}.
+     */
+    public boolean isJsNew();
 
 }


### PR DESCRIPTION
These three commits add support for instantiating TypeScript classes with the `new` operator. See individual commit messages for details.

Note: I’m on a mostly-CLI environment (no IDE), and haven’t had to write JavaDoc in a while (yay!), so I might’ve gotten the syntax wrong. It would be great if you could check that.
