### PR TITLE
Attempted fix for infinite recursion in identityHash()

### DIFF
--- a/compiler-js/src/test/ceylon/dyns/issues_dyns.ceylon
+++ b/compiler-js/src/test/ceylon/dyns/issues_dyns.ceylon
@@ -271,6 +271,7 @@ shared void issues() {
     issue604();
     issue5952();
     issue5959();
+    issue6057();
 }
 
 void issue5952() {
@@ -329,4 +330,10 @@ void issue5959() {
     check((d of Object) is D5959<Integer>, "#5959 targs 2");
     check((d of Object) is C5959<String>, "#5959 targs3");
   }
+}
+
+void issue6057() {
+  dynamic DefaultObject {}
+  dynamic { DefaultObject o = eval("this"); }
+  check(identityHash(object extends Basic() {}) > 0, "#6057 1");
 }

--- a/language/src/ceylon/language/identityHash.ceylon
+++ b/language/src/ceylon/language/identityHash.ceylon
@@ -18,7 +18,7 @@ Integer identityHash(Identifiable identifiable) {
             return hash;
         }
         else {
-            hash = \iBasicID++;
+            Integer hash = \iBasicID++;
             x.\iBasicID = hash;
             return hash;
         }


### PR DESCRIPTION
In the else block, there is no `hash` value. This is however inside a dynamic block so the compiler passes the references as-is into javascript code. Since there actually is no "hash" variable in scope in javascript, references to `hash` will be stored/retrieved in the `window` object on lines 21-23.

Normally this happens to work. Except when using ceylon.interop.browser, the `window` object gets `dre$$`ed with a `hash` attribute. This is set up as a javascript property with a getter and an undefined setter. In this case line 21 actually has no effect (setter undefined) and line 22 actually calls the `dre$$`ed hash attribute getter function. Coincidentally the hash attribute getter function calls identityHash(), which on line 22 calls the hash attribute getter function etc.

This means that as soon as the window object has been `dre$$`ed, getting the identityHash for _any_ object results in an infinite recursion. For example:

``` ceylon

import ceylon.interop.browser { window }

class Foo() {}

shared void run() {
    value x = window; // trigger dre$$ of window object
    print(Foo()); // fail - default string attribute includes hash, which is
                  // by default calculated by identityHash()
}
```
