### PR TITLE
Fix NPE affecting all generic type aliases on JS

### DIFF
--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
@@ -763,19 +763,21 @@ public class JsonPackage extends com.redhat.ceylon.model.typechecker.model.Packa
                 throw new IllegalStateException(maybe + " should be an TypeAlias");
             }
         }
-        //All interfaces extend Object, except aliases
-        if (alias.getExtendedType() == null) {
-            alias.setExtendedType(getTypeFromJson((Map<String,Object>)m.get("$alias"),
-                    parent instanceof Declaration ? (Declaration)parent : null, existing));
-        }
+        //Gather available type parameters
         List<Map<String,Object>> listOfMaps = (List<Map<String,Object>>)m.get(MetamodelGenerator.KEY_TYPE_PARAMS);
         final List<TypeParameter> tparms;
         if (listOfMaps != null && alias.getTypeParameters().size()<listOfMaps.size()) {
             tparms = parseTypeParameters(listOfMaps, alias, existing);
+            alias.setTypeParameters(tparms);
         } else {
             tparms = alias.getTypeParameters();
         }
         final List<TypeParameter> allparms = JsonPackage.merge(tparms, existing);
+        //All interfaces extend Object, except aliases
+        if (alias.getExtendedType() == null) {
+            alias.setExtendedType(getTypeFromJson((Map<String,Object>)m.get("$alias"),
+                    parent instanceof Declaration ? (Declaration)parent : null, allparms));
+        }
         if (m.containsKey(MetamodelGenerator.KEY_SELF_TYPE)) {
             for (TypeParameter _tp : tparms) {
                 if (_tp.getName().equals(m.get(MetamodelGenerator.KEY_SELF_TYPE))) {


### PR DESCRIPTION
This adds JS model loader support for type aliases like

``` ceylon
alias Alias<T> => T;
```

and is necessary to support importing of @thradec's `ceylon.html5` module.
