### PR TITLE
Fix typos in the specification (`i` → `n`).

### DIFF
--- a/typechecker/en/modules/expressions.xml
+++ b/typechecker/en/modules/expressions.xml
@@ -2674,12 +2674,12 @@ Digit{1,2} ":" Digit{2} ( ":" Digit{2} ( ":" Digit{3} )? )?
     
     <itemizedlist>
         <listitem>
-            <para>The type of an expression of form <literal>x[i]</literal> where
+            <para>The type of an expression of form <literal>x[n]</literal> where
             <literal>x</literal> is of the sequence type <literal>X</literal> and 
             <literal>n</literal> is an integer literal is <literal>En</literal>.</para>
         </listitem>
         <listitem>
-            <para>The type of an expression of form <literal>x[i...]</literal> where
+            <para>The type of an expression of form <literal>x[n...]</literal> where
             <literal>x</literal> is of the sequence type <literal>X</literal> and 
             <literal>n</literal> is an integer literal is <literal>Xn</literal> if
             <literal>Xn</literal> is an instantiation of <literal>Tuple</literal>,


### PR DESCRIPTION
In this paragraph `i` was used in a way that didn't make any sense.
Replacing it with `n` (which was defined in the same sentence) makes it sensible again.

The formatted spec (currently with the error): http://ceylon-lang.org/documentation/current/spec/html_single/index.html#listmap
