### PR TITLE
Remove expr use from ceylon sh script

### DIFF
--- a/common/bin/ceylon
+++ b/common/bin/ceylon
@@ -4,10 +4,12 @@
 PRG="$0"
 while [ -h "$PRG" ]; do
     ls="$(ls -ld "$PRG")"
-    link="$(expr "$ls" : '.*-> \(.*\)$')"
-    if expr "$link" : '/.*' > /dev/null; then
+    link="${ls##*-> }" # remove largest prefix: yields link target (behind ->)
+    if [ "$link" != "${link#/}" ]; then # remove prefix / if present
+        # path was absolute
         PRG="$link"
     else
+        # was not
         PRG="$(dirname "$PRG")/$link"
     fi
 done

--- a/common/bin/ceylon
+++ b/common/bin/ceylon
@@ -57,9 +57,9 @@ if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
         CEYL_COLS="$(tput 2>/dev/null cols)"
     fi
     PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.width=$CEYL_COLS"
-    PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.reset=$(tput 2>/dev/null sgr0)"
     PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.green=$(tput 2>/dev/null setaf 2)"
     PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.red=$(tput 2>/dev/null setaf 1)"
+    PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.reset=$(tput 2>/dev/null sgr0)"
     PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.progname=$(basename "$PRG")"
 fi
 JAVA_OPTS="$PREPEND_JAVA_OPTS $JAVA_OPTS"


### PR DESCRIPTION
I thought `${var#prefix}` was a Bashism, but it’s actually part of POSIX, and supported by Bash, Dash, [and Mac’s sh](https://gitter.im/ceylon/dev?at=56e202a5bb541ac77f4f0416)¹. So this saves us at least one spawned process per ceylon invocation, and two on shells where `[` is a builtin (Bash, Dash).

We _could_ also replace the `dirname` use below with something like `${PRG##*/}`, but that’s not entirely equivalent (POSIX describes an eight-step procedure for `dirname`). On the one hand, we probably don’t care about the difference. But on the other hand, we probably care even less about the performance hit of the `dirname` use, so let’s just stay on the safe (and readable) side here.

¹ which, in hindsight, I needn’t have asked anyone to verify, since OS X since 10.5 Leopard is _certified_ POSIX compliant.
