### PR TITLE
Hard-code ANSI escape sequences for common terminals

### DIFF
--- a/cli/bin/ceylon
+++ b/cli/bin/ceylon
@@ -57,11 +57,25 @@ if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
         CEYL_COLS="$(tput 2>/dev/null cols)"
     fi
     PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.width=$CEYL_COLS"
-    PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.red=$(tput 2>/dev/null setaf 1)"
-    PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.green=$(tput 2>/dev/null setaf 2)"
-    PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.yellow=$(tput 2>/dev/null setaf 3)"
-    PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.blue=$(tput 2>/dev/null setaf 4)"
-    PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.reset=$(tput 2>/dev/null sgr0)"
+    case "$TERM" in
+        xterm*|screen*|linux*|ansi*)
+            # ANSI escape sequences
+            e="$(printf '\033')"
+            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.red=${e}[31m"
+            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.green=${e}[32m"
+            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.yellow=${e}[33m"
+            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.blue=${e}[34m"
+            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.reset=${e}[0m"
+            ;;
+        *)
+            # unknown escape sequences, consult terminfo/termcap
+            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.red=$(tput 2>/dev/null setaf 1)"
+            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.green=$(tput 2>/dev/null setaf 2)"
+            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.yellow=$(tput 2>/dev/null setaf 3)"
+            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.blue=$(tput 2>/dev/null setaf 4)"
+            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.reset=$(tput 2>/dev/null sgr0)"
+            ;;
+    esac
     PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.progname=$(basename "$PRG")"
 fi
 JAVA_OPTS="$PREPEND_JAVA_OPTS $JAVA_OPTS"


### PR DESCRIPTION
Since almost every modern terminal pretends to be an `xterm`, and tmux pretends to be a `screen`, this should save us a whopping nine spawned processes (five `tput`, five subshells, minus one for the `printf` subshell) per `ceylon` invocation on the vast majority of terminals.

---

You can verify that all listed terminals use these sequences with this command (Bash):

``` bash
for term in /usr/share/terminfo/*/*; do term="$(basename "$term")"; case "$term" in xterm*|screen*|linux*|ansi*) [[ "$(tput -T"$term" setaf 1)" == $'\e[31m' ]] || [[ "$(tput -T"$term" setaf 1)" == "" ]] || echo $term;; esac; done
```

Only two terminals in my Terminfo database deviate from this:
- `linux-16color` gives you `\e[31;21m`. The added `21m`, according to Wikipedia, turns off Bold (“not widely supported”) or enables Double Underline (“hardly ever supported”). Don’t care.
- `xterm-8bit` gives you `X31m`, where `X` stands for the character `0x9B` (outside of ASCII, hence `8bit`). According to Wikipedia, `0x9B` (single character) is a little-used alternative to `\e[` (two characters). However, `\e[` should still be supported, so we don’t care.

For `sgr0`, the situation is a bit more complicated. According to Wikipedia, per ANSI, `\e[0m` sets “all attributes off”. Some terminals give you `\e[0;10m`; the added `10m` selects the default font (`11`-`19` select alternate fonts). I’m not sure if just `\e[0m`, “all attributes off ”, should include that, but we’re not setting any fonts anyways, so we don’t care. And `xterm` gives you `\e(B\e[m`; I have no idea what the `\e(B` does (I’ve never even _seen_ a `[` instead of a `(` there), but just `\e0m` also works, so we don’t care about this too.
