### PR TITLE
Fix #6158

### DIFF
--- a/cli/bin/ceylon
+++ b/cli/bin/ceylon
@@ -57,25 +57,27 @@ if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
         CEYL_COLS="$(tput 2>/dev/null cols)"
     fi
     PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.width=$CEYL_COLS"
-    case "$TERM" in
-        xterm*|screen*|linux*|ansi*)
-            # ANSI escape sequences
-            e="$(printf '\033')"
-            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.red=${e}[31m"
-            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.green=${e}[32m"
-            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.yellow=${e}[33m"
-            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.blue=${e}[34m"
-            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.reset=${e}[0m"
-            ;;
-        *)
-            # unknown escape sequences, consult terminfo/termcap
-            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.red=$(tput 2>/dev/null setaf 1)"
-            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.green=$(tput 2>/dev/null setaf 2)"
-            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.yellow=$(tput 2>/dev/null setaf 3)"
-            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.blue=$(tput 2>/dev/null setaf 4)"
-            PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.reset=$(tput 2>/dev/null sgr0)"
-            ;;
-    esac
+    if [ -t 1 ] && [ -t 2 ]; then
+        case "$TERM" in
+            xterm*|screen*|linux*|ansi*)
+                # ANSI escape sequences
+                e="$(printf '\033')"
+                PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.red=${e}[31m"
+                PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.green=${e}[32m"
+                PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.yellow=${e}[33m"
+                PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.blue=${e}[34m"
+                PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.reset=${e}[0m"
+                ;;
+            *)
+                # unknown escape sequences, consult terminfo/termcap
+                PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.red=$(tput 2>/dev/null setaf 1)"
+                PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.green=$(tput 2>/dev/null setaf 2)"
+                PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.yellow=$(tput 2>/dev/null setaf 3)"
+                PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.blue=$(tput 2>/dev/null setaf 4)"
+                PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.terminal.color.reset=$(tput 2>/dev/null sgr0)"
+                ;;
+        esac
+    fi
     PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -Dcom.redhat.ceylon.common.tool.progname=$(basename "$PRG")"
 fi
 JAVA_OPTS="$PREPEND_JAVA_OPTS $JAVA_OPTS"


### PR DESCRIPTION
Terminal escape sequences are only set if standard output (file descriptor 1) and standard error (file descriptor 2) are both associated with a terminal.
