### PR TITLE
Implement #6172: parameter/argument warning

### DIFF
--- a/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
+++ b/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/ExpressionVisitor.java
@@ -4336,6 +4336,8 @@ public class ExpressionVisitor extends Visitor {
                     else {
                         checkPositionalArgument(param, pr, 
                                 (Tree.ListedArgument) arg);
+                        checkPositionalArgumentPosition(
+                                i, param, args);
                     }
                 }
             }
@@ -4739,6 +4741,48 @@ public class ExpressionVisitor extends Visitor {
                 checkAssignable(at, paramType, a, 
                         "argument must be assignable to parameter " + 
                                 argdesc(p, pr), 2100);
+            }
+        }
+    }
+    
+    /**
+     * Warns if argument and parameter names don't match (#6172)
+     */
+    private void checkPositionalArgumentPosition(
+            int paramIndex, Parameter param, List<Tree.PositionalArgument> args) {
+        String paramName = param.getName();
+        if (paramIndex < args.size()) {
+            Tree.PositionalArgument currentArg = args.get(paramIndex);
+            if (currentArg instanceof Tree.ListedArgument) {
+                Tree.Term currentArgTerm = unwrapExpressionUntilTerm(
+                        ((Tree.ListedArgument)currentArg).getExpression());
+                if (currentArgTerm instanceof Tree.BaseMemberExpression) {
+                    String currentArgName = ((Tree.BaseMemberExpression)currentArgTerm)
+                        .getIdentifier().getText();
+                    if (currentArgName.equals(paramName)) {
+                        return;
+                    }
+                }
+            }
+        }
+        for (int otherArgIndex = 0; otherArgIndex < args.size(); otherArgIndex++) {
+            if (otherArgIndex == paramIndex) continue;
+            Tree.PositionalArgument otherArg = args.get(otherArgIndex);
+            if (otherArg instanceof Tree.ListedArgument) {
+                Tree.Term otherArgTerm = unwrapExpressionUntilTerm(
+                        ((Tree.ListedArgument)otherArg).getExpression());
+                if (otherArgTerm instanceof Tree.BaseMemberExpression) {
+                    String otherArgName = ((Tree.BaseMemberExpression)otherArgTerm)
+                        .getIdentifier().getText();
+                    if (otherArgName.equals(paramName)) {
+                        otherArg.addUsageWarning(
+                                Warning.suspiciousArgument,
+                                "argument '" + otherArgName +
+                                "' does not assign to parameter '" +
+                                paramName + "'; consider using named arguments " +
+                                "if this is intentional");
+                    }
+                }
             }
         }
     }

--- a/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/Warning.java
+++ b/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/Warning.java
@@ -20,5 +20,6 @@ public enum Warning {
     javaAnnotationElement,
     syntaxDeprecation,
     smallIgnored,
-    literalNotSmall
+    literalNotSmall,
+    suspiciousArgument
 }


### PR DESCRIPTION
If the parameter is not assigned by a BME with the same name, but a different argument is a BME with the same name, issue a warning.

Warnings in language module and SDK: [gist](https://gist.github.com/lucaswerkmeister/d5a2fde24c5a4ce926fd6fe598c844f3)

Closes #6172.
