### PR TITLE
Add iterate alias to loop function

### DIFF
--- a/language/src/ceylon/language/loop.ceylon
+++ b/language/src/ceylon/language/loop.ceylon
@@ -10,6 +10,7 @@
 
  produces the stream `{ 0, 2, 4, 6, 8 }`."
 tagged("Streams")
+aliased("iterate")
 shared {Element+} loop<Element>(
         "The first element of the resulting stream."
         Element first)(


### PR DESCRIPTION
`iterate` is the Haskell name of this function.

---

I’m not saying we have to add this – feel free to disagree – but this feels like a function that most people might know, if at all, by its Haskell name.
