### PR TITLE
remove spurious check in emptyMeet for sequentials

### DIFF
--- a/model/src/com/redhat/ceylon/model/typechecker/model/ModelUtil.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/ModelUtil.java
@@ -1560,8 +1560,7 @@ public class ModelUtil {
                 !st.inherits(qd) ||
             p.isClassOrInterface() &&
                 qd.inherits(st) && !pd.inherits(st) && 
-                !st.inherits(pd) && 
-                !p.involvesTypeParameters()) {
+                !st.inherits(pd)) {
             return true;
         }
         

--- a/typechecker/test/main/cases/enumeratedbounds.ceylon
+++ b/typechecker/test/main/cases/enumeratedbounds.ceylon
@@ -37,3 +37,7 @@ class Lizt<out Item>() {
         return i of Item; 
     }
 }
+
+class C<T,U>() given T of String[]|Map<String,U> {}
+
+class D<T,U>() given T of Map<String,U>|String[] {}


### PR DESCRIPTION
The spec states that X & Y are disjoint if:

```
X is a subtype of some instantiation of Sequential, Y is an
instantiation of a class or interface that is not a subtype of any
instantiation of Sequential, and Y is not an instantiation of a
class or interface that is inherited by Sequential,
```

There is no mention of Y not involving type parameters, nor was there a
similar check at line 1560.
