### PR TITLE
fix #6244 compiler bug: visitor didn't yield any result

### DIFF
--- a/compiler-java/test/src/com/redhat/ceylon/compiler/java/test/interop/Bug6244.ceylon
+++ b/compiler-java/test/src/com/redhat/ceylon/compiler/java/test/interop/Bug6244.ceylon
@@ -1,0 +1,5 @@
+class Main() extends Base2() {
+	void foo(ArgType2 arg) {
+		add(arg);
+	}
+}

--- a/compiler-java/test/src/com/redhat/ceylon/compiler/java/test/interop/Bug6244Java.java
+++ b/compiler-java/test/src/com/redhat/ceylon/compiler/java/test/interop/Bug6244Java.java
@@ -1,0 +1,14 @@
+package com.redhat.ceylon.compiler.java.test.interop;
+
+class ArgType1 {}
+
+class ArgType2 {}
+
+class Base1 {
+	public void add(ArgType1... argType1s) {}
+}
+
+class Base2 extends Base1 {
+	public void add(ArgType2... argType2s) {}
+}
+

--- a/compiler-java/test/src/com/redhat/ceylon/compiler/java/test/interop/InteropTests.java
+++ b/compiler-java/test/src/com/redhat/ceylon/compiler/java/test/interop/InteropTests.java
@@ -758,4 +758,10 @@ public class InteropTests extends CompilerTests {
                 || JDKUtils.jdk == JDKUtils.JDK.JDK9);
         compareWithJavaSource("RefineDefaultInterfaceMethod");
     }
+    
+    @Test
+    public void testBug6244(){
+        compile("Bug6244Java.java");
+        compile("Bug6244.ceylon");
+    }
 }

--- a/model/src/com/redhat/ceylon/model/loader/AbstractModelLoader.java
+++ b/model/src/com/redhat/ceylon/model/loader/AbstractModelLoader.java
@@ -3267,6 +3267,7 @@ public abstract class AbstractModelLoader implements ModelCompleter, ModelLoader
         method.setRealName(methodName);
         method.setUnit(klass.getUnit());
         method.setOverloaded(isOverloaded || isOverloadingMethod(methodMirror));
+        method.setVariadic(methodMirror.isVariadic());
         Type type = null;
         try{
             setMethodOrValueFlags(klass, methodMirror, method, isCeylon);

--- a/model/src/com/redhat/ceylon/model/loader/model/JavaMethod.java
+++ b/model/src/com/redhat/ceylon/model/loader/model/JavaMethod.java
@@ -14,6 +14,8 @@ import com.redhat.ceylon.model.typechecker.model.Function;
  */
 public class JavaMethod extends Function implements LocalDeclarationContainer {
 
+    private static final int VARIADIC = 1<<26;
+
     private String realName;
     private boolean defaultedAnnotation;
     public final MethodMirror mirror;
@@ -34,6 +36,20 @@ public class JavaMethod extends Function implements LocalDeclarationContainer {
 
     public String getRealName(){
         return realName;
+    }
+    
+    @Override
+    public boolean isVariadic() {
+        return (flags&VARIADIC)!=0;
+    }
+    
+    public void setVariadic(boolean variadic) {
+        if (variadic) {
+            flags|=VARIADIC;
+        }
+        else {
+            flags&=(~VARIADIC);
+        }
     }
     
     /**

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Declaration.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Declaration.java
@@ -382,6 +382,10 @@ public abstract class Declaration
         }
     }
 
+    public boolean isVariadic() {
+        return false;
+    }
+    
     /**
      * Get a produced reference for this declaration
      * by binding explicit or inferred type arguments

--- a/model/src/com/redhat/ceylon/model/typechecker/model/TypeDeclaration.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/TypeDeclaration.java
@@ -678,7 +678,7 @@ public abstract class TypeDeclaration extends Declaration
                     Declaration dm = 
                             type.getDirectMember(
                                     member.getName(), 
-                                    signature, false);
+                                    signature, member.isVariadic());
                     return dm!=null && dm.equals(member);
                 }
             }


### PR DESCRIPTION
The root of the problem is having two overloaded variable arity methods and unqualified call from subclass to one of this methods.
