### PR TITLE
Generalize dynamic flag

### DIFF
--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/BmeGenerator.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/BmeGenerator.java
@@ -264,6 +264,9 @@ public class BmeGenerator {
                     gen.qualify(that, d);
                 }
             } else {
+                if (d instanceof Class && ((Class)d).isDynamic()) {
+                    gen.out("new ");
+                }
                 gen.qualify(that, d);
             }
             gen.out(gen.getNames().name(d));

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/ClassGenerator.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/ClassGenerator.java
@@ -27,8 +27,8 @@ public class ClassGenerator {
         //Don't even bother with nodes that have errors
         if (TypeGenerator.errVisitor.hasErrors(that))return;
         final Class d = that.getDeclarationModel();
-        //If it's inside a dynamic interface, don't generate anything
-        if (d.isClassOrInterfaceMember() && ((ClassOrInterface)d.getContainer()).isDynamic())return;
+        //If it's inside a dynamic interface (or for some other reason dynamic), don't generate anything
+        if (d.isDynamic())return;
         final Class natd = (Class)ModelUtil.getNativeDeclaration(d, Backend.JavaScript);
         final boolean headerWithoutBackend = NativeUtil.isHeaderWithoutBackend(that, Backend.JavaScript);
         if (natd!= null && (headerWithoutBackend || NativeUtil.isNativeHeader(that))) {

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/InvocationGenerator.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/InvocationGenerator.java
@@ -93,7 +93,6 @@ public class InvocationGenerator {
         } else {
             gen.out("(");
             Map<String, String> argVarNames = defineNamedArguments(typeArgSource, argList);
-            writeNew(typeArgSource);
             if (typeArgSource instanceof Tree.BaseMemberExpression) {
                 BmeGenerator.generateBme((Tree.BaseMemberExpression)typeArgSource, gen);
             } else if (typeArgSource instanceof Tree.QualifiedTypeExpression) {
@@ -143,7 +142,6 @@ public class InvocationGenerator {
             //TODO we lose type args for now
             return;
         } else {
-            writeNew(typeArgSource);
             if (typeArgSource instanceof Tree.BaseMemberExpression) {
                 final Tree.BaseMemberExpression _bme = (Tree.BaseMemberExpression)typeArgSource;
                 if (gen.isInDynamicBlock() && _bme.getDeclaration() != null &&
@@ -705,22 +703,6 @@ public class InvocationGenerator {
             gen.out("[]");
         } else {
             TypeUtils.encodeParameterListForRuntime(true, term, plist, gen);
-        }
-    }
-
-    /**
-     * Emit {@code new} if the invoked function should be invoked with {@code new}.
-     * @see Functional#isJsNew()
-     */
-    void writeNew(Tree.Primary invoked) {
-        if (invoked instanceof Tree.BaseTypeExpression) {
-            Tree.BaseTypeExpression bte = (Tree.BaseTypeExpression)invoked;
-            if (bte.getDeclaration() instanceof Functional) {
-                Functional f = (Functional)bte.getDeclaration();
-                if (f.isJsNew()) {
-                    gen.out("new ");
-                }
-            }
         }
     }
 

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/TypeGenerator.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/TypeGenerator.java
@@ -295,8 +295,8 @@ public class TypeGenerator {
         //Don't even bother with nodes that have errors
         if (errVisitor.hasErrors(that))return;
         final Interface d = that.getDeclarationModel();
-        //If it's inside a dynamic interface, don't generate anything
-        if (d.isClassOrInterfaceMember() && ((ClassOrInterface)d.getContainer()).isDynamic())return;
+        //If it's inside a dynamic interface (or for some other reason dynamic), don't generate anything
+        if (d.isDynamic())return;
         final Interface natd = (Interface)ModelUtil.getNativeDeclaration(d, Backend.JavaScript);
         final boolean headerWithoutBackend = NativeUtil.isHeaderWithoutBackend(that, Backend.JavaScript);
         if (natd!= null && (headerWithoutBackend || NativeUtil.isNativeHeader(that))) {

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
@@ -339,6 +339,12 @@ public class JsonPackage extends LazyPackage {
                 loadClass(cdef.getKey(), cdef.getValue(), cls, allparms);
             }
         }
+        if (cls.isDynamic() &&
+                (getModule().getJsMajor()<9 ||
+                    (getModule().getJsMajor()==9 && getModule().getJsMinor()<1))) {
+            // previous versions did not set dynamic flag on members
+            cls.makeMembersDynamic();
+        }
         return cls;
     }
 
@@ -730,6 +736,12 @@ public class JsonPackage extends LazyPackage {
             for (Map.Entry<String,Map<String,Object>> cdef : cdefs.entrySet()) {
                 loadClass(cdef.getKey(), cdef.getValue(), t, allparms);
             }
+        }
+        if (t.isDynamic() &&
+                (getModule().getJsMajor()<9 ||
+                    (getModule().getJsMajor()==9 && getModule().getJsMinor()<1))) {
+            // previous versions did not set dynamic flag on members
+            t.makeMembersDynamic();
         }
         return t;
     }

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
@@ -218,6 +218,7 @@ public class JsonPackage extends LazyPackage {
             }
             cls.setAbstract(m.remove("abstract") != null);
             cls.setAnonymous(m.remove("$anon") != null);
+            cls.setDynamic(m.remove(KEY_DYNAMIC) != null);
             cls.setContainer(parent);
             cls.setName(name);
             cls.setUnit(u2);
@@ -267,9 +268,7 @@ public class JsonPackage extends LazyPackage {
                 cnst.setScope(cls);
                 cnst.setUnit(cls.getUnit());
                 cnst.setExtendedType(cls.getType());
-                if (cons.getValue().containsKey(KEY_JS_NEW)) {
-                    cnst.setJsNew((Boolean)cons.getValue().remove(KEY_JS_NEW));
-                }
+                cnst.setDynamic(cons.getValue().remove(KEY_DYNAMIC) != null);
                 setAnnotations(cnst, (Integer)cons.getValue().remove(KEY_PACKED_ANNS),
                         (Map<String,Object>)cons.getValue().remove(KEY_ANNOTATIONS));
                 final List<Map<String,Object>> modelPlist = (List<Map<String,Object>>)cons.getValue().remove(
@@ -304,7 +303,7 @@ public class JsonPackage extends LazyPackage {
                     cf.setVisibleScope(cnst.getVisibleScope());
                     cf.setShared(cnst.isShared());
                     cf.setDeprecated(cnst.isDeprecated());
-                    cf.setJsNew(cnst.isJsNew());
+                    cf.setDynamic(cnst.isDynamic());
                     cls.addMember(cf);
                 }
             }

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/MetamodelGenerator.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/MetamodelGenerator.java
@@ -395,6 +395,9 @@ public class MetamodelGenerator {
         final Map<String, Object> m = new HashMap<>();
         m.put(KEY_METATYPE, METATYPE_METHOD);
         m.put(KEY_NAME, d.getName());
+        if (d.isDynamic()) {
+            m.put(KEY_DYNAMIC, 1);
+        }
         List<Map<String, Object>> tpl = typeParameters(d.getTypeParameters(), d);
         if (tpl != null) {
             m.put(KEY_TYPE_PARAMS, tpl);
@@ -609,6 +612,9 @@ public class MetamodelGenerator {
         m.put(KEY_NAME, d.getName());
         m.put(KEY_METATYPE, (d instanceof Value && ((Value)d).isTransient()) ? METATYPE_GETTER : METATYPE_ATTRIBUTE);
         m.put(KEY_TYPE, typeMap(d.getType(), d));
+        if (d.isDynamic()) {
+            m.put(KEY_DYNAMIC, 1);
+        }
         parent.put(mname, m);
         encodeAnnotations(d.getAnnotations(), d, m);
         if (d instanceof Value && ((Value) d).getSetter() != null) {

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/NpmPackage.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/NpmPackage.java
@@ -53,7 +53,6 @@ public class NpmPackage extends LazyPackage {
                 plist.getParameters().add(p0);
                 //Add a default constructor with jsNew set
                 Constructor defcon = new Constructor();
-                defcon.setJsNew(true);
                 defcon.addParameterList(plist);
                 defcon.setDynamic(true);
                 defcon.setShared(true);
@@ -68,7 +67,7 @@ public class NpmPackage extends LazyPackage {
                 cf.setUnit(d.getUnit());
                 cf.setVisibleScope(defcon.getVisibleScope());
                 cf.setShared(true);
-                cf.setJsNew(true);
+                cf.setDynamic(true);
                 ((Class)d).setConstructors(true);
                 ((Class)d).addMember(defcon);
                 ((Class)d).addMember(cf);

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/NpmPackage.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/NpmPackage.java
@@ -73,6 +73,7 @@ public class NpmPackage extends LazyPackage {
                 ((Class)d).addMember(cf);
             } else {
                 d = new Function();
+                ((Function)d).setDynamic(true);
                 ((Function)d).setDynamicallyTyped(true);
             }
             d.setName(name);

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/util/JsIdentifierNames.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/util/JsIdentifierNames.java
@@ -297,7 +297,7 @@ public class JsIdentifierNames {
         if (name.startsWith("anonymous#")) {
             name="anon$" + name.substring(10);
         }
-        if (decl.isClassOrInterfaceMember() && ((ClassOrInterface)decl.getContainer()).isDynamic()) {
+        if (decl.isDynamic()) {
             return JsUtils.escapeStringLiteral(decl.getName());
         }
         boolean nonLocal = !priv;

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Class.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Class.java
@@ -242,18 +242,6 @@ public class Class extends ClassOrInterface implements Functional {
     	return (flags&OVERLOADED)!=0;
     }
     
-    @Override
-    public boolean isJsNew() {
-        if (hasConstructors()) {
-            Constructor defaultConstructor = 
-                    getDefaultConstructor();
-            return defaultConstructor!=null &&
-                    defaultConstructor.isJsNew();
-        } else {
-            return false;
-        }
-    }
-    
     public void setOverloaded(boolean overloaded) {
         if (overloaded) {
             flags|=OVERLOADED;

--- a/model/src/com/redhat/ceylon/model/typechecker/model/ClassOrInterface.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/ClassOrInterface.java
@@ -218,4 +218,13 @@ public abstract class ClassOrInterface extends TypeDeclaration {
         ModelUtil.clearProducedTypeCache(this);
     }
     
+    public void makeMembersDynamic() {
+        for (Declaration m : getMembers()) {
+            m.setDynamic(true);
+            if (m instanceof ClassOrInterface) {
+                ((ClassOrInterface)m).makeMembersDynamic();
+            }
+        }
+    }
+    
 }

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Constructor.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Constructor.java
@@ -18,7 +18,6 @@ public class Constructor extends TypeDeclaration implements Functional {
     private static final int ABSTRACT = 1<<13;
     private static final int OVERLOADED = 1<<19;
     private static final int ABSTRACTION = 1<<20;
-    private static final int JS_NEW = 1<<25;
     
     private ParameterList parameterList;
     private List<Declaration> overloads;
@@ -94,20 +93,6 @@ public class Constructor extends TypeDeclaration implements Functional {
     @Override
     public boolean isAbstraction() {
         return (flags&ABSTRACTION)!=0;
-    }
-    
-    @Override
-    public boolean isJsNew() {
-        return (flags&JS_NEW)!=0;
-    }
-    
-    public void setJsNew(boolean $new) {
-        if ($new) {
-            flags|=JS_NEW;
-        }
-        else {
-            flags&=(~JS_NEW);
-        }
     }
     
     @Override

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Declaration.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Declaration.java
@@ -32,6 +32,7 @@ public abstract class Declaration
     private static final int DEFAULT = 1<<3;
     private static final int ANNOTATION = 1<<4;
     private static final int DEPRECATED = 1<<5;
+    private static final int DYNAMIC = 1<<6;
     
     private static final int PROTECTED = 1<<8;
     private static final int PACKAGE = 1<<9;
@@ -95,6 +96,27 @@ public abstract class Declaration
             flags&=(~DEPRECATED);
         }
 	}
+    
+    /**
+     * Whether this declaration is dynamic, that is, outside of Ceylon's control
+     * (such as a dynamic interface).
+     * Not to be confused with {@link TypedDeclaration#isDynamicallyTyped()}.
+     */
+    public boolean isDynamic() {
+        return (flags&DYNAMIC)!=0;
+    }
+    
+    /**
+     * @see #isDynamic()
+     */
+    public void setDynamic(boolean dynamic) {
+        if (dynamic) {
+            flags|=DYNAMIC;
+        }
+        else {
+            flags&=(~DYNAMIC);
+        }
+    }
 
     String toStringName() {
         String name = getName();

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Function.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Function.java
@@ -18,7 +18,6 @@ public class Function extends FunctionOrValue implements Generic, Scope, Functio
     private static final int VOID = 1<<22;
     private static final int DEFERRED = 1<<23;
     private static final int NO_NAME = 1<<24;
-    private static final int JS_NEW = 1<<25;
     
     private List<TypeParameter> typeParameters = emptyList();
     private List<ParameterList> parameterLists = new ArrayList<ParameterList>(1);
@@ -123,20 +122,6 @@ public class Function extends FunctionOrValue implements Generic, Scope, Functio
     @Override
     public boolean isNamed() {
         return (flags&NO_NAME)==0;
-    }
-
-    @Override
-    public boolean isJsNew() {
-        return (flags&JS_NEW)!=0;
-    }
-    
-    public void setJsNew(boolean $new) {
-        if ($new) {
-            flags|=JS_NEW;
-        }
-        else {
-            flags&=(~JS_NEW);
-        }
     }
     
     @Override

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Functional.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Functional.java
@@ -25,11 +25,5 @@ public interface Functional {
 //    public List<TypeParameter> getTypeParameters();
     
     public boolean isDeclaredVoid();
-    /**
-     * Returns {@code true} if this is a constructor that should,
-     * on the JavaScript backend,
-     * be instantiated with {@code new}.
-     */
-    public boolean isJsNew();
 
 }

--- a/model/src/com/redhat/ceylon/model/typechecker/model/TypeDeclaration.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/TypeDeclaration.java
@@ -34,7 +34,6 @@ public abstract class TypeDeclaration extends Declaration
     private Type selfType;
     private List<Type> brokenSupertypes = null; // delayed allocation
     private boolean inconsistentType;
-    private boolean dynamic;
 	private boolean sealed;
     private List<TypedDeclaration> caseValues;
 
@@ -52,14 +51,6 @@ public abstract class TypeDeclaration extends Declaration
 	
 	public void setSealed(boolean sealed) {
 	    this.sealed = sealed;
-    }
-    
-    public boolean isDynamic() {
-        return dynamic;
-    }
-    
-    public void setDynamic(boolean dynamic) {
-        this.dynamic = dynamic;
     }
     
     public boolean isInconsistentType() {

--- a/model/src/com/redhat/ceylon/model/typechecker/model/TypedDeclaration.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/TypedDeclaration.java
@@ -19,22 +19,29 @@ public abstract class TypedDeclaration extends Declaration {
     private static final int UNBOXED = 1<<13;
     private static final int TYPE_ERASED = 1<<14;
     private static final int UNTRUSTED_TYPE = 1<<15;
-    private static final int DYNAMIC = 1<<16;
+    private static final int DYNAMICALLY_TYPED = 1<<16;
     
     private Type type;
     
     private TypedDeclaration originalDeclaration;
     
+    /**
+     * Whether this declaration is dynamically typed, that is,
+     * has the {@code dynamic} keyword as return type.
+     */
     public boolean isDynamicallyTyped() {
-        return (flags&DYNAMIC)!=0;
+        return (flags&DYNAMICALLY_TYPED)!=0;
     }
     
+    /**
+     * @see #isDynamicallyTyped()
+     */
     public void setDynamicallyTyped(boolean dynamicallyTyped) {
         if (dynamicallyTyped) {
-            flags|=DYNAMIC;
+            flags|=DYNAMICALLY_TYPED;
         }
         else {
-            flags&=(~DYNAMIC);
+            flags&=(~DYNAMICALLY_TYPED);
         }
     }
         

--- a/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/DeclarationVisitor.java
+++ b/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/DeclarationVisitor.java
@@ -1043,6 +1043,9 @@ public abstract class DeclarationVisitor extends Visitor {
         if (i.isNativeImplementation()) {
             addMissingHeaderMembers(i);
         }
+        if (i.isDynamic()) {
+            i.makeMembersDynamic();
+        }
         // Required by IDE to be omitted: https://github.com/ceylon/ceylon-compiler/issues/2326
 //        if (that.getDynamic()) {
 //            checkDynamic(that);


### PR DESCRIPTION
This moves the `dynamic` flag from `TypeDeclaration` to `Declaration` and removes the `jsNew` flag.

@chochos I was working on this in an older branch (before NPM support), and was surprised to discover that the backend still correctly emitted `new` for dynamic classes after I removed `jsNew` – the backend already knew how to treat dynamic classes correctly, which I wasn’t aware of when I wrote #6050. After I rebased on `master`, this broke, because you removed [this](https://github.com/ceylon/ceylon/blob/5c89be787ff7dc07ec527c44e2ce8e71dd131f33/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/BmeGenerator.java#L267-L269) bit in 9bb42bb. I’ve added it back (removing [this](https://github.com/ceylon/ceylon/blob/a1a79d5a93046132704f87af2ada175306b9ca4b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/InvocationGenerator.java#L711-L725) from #6050), because the old version looks better to me. Do you agree?

Also, @gavinking might want to glance over the model part of the changes.
