### PR TITLE
Restructuring Gradle Build #2 - Fixing the unnitentional dependency on the Ant build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,13 @@ buildScan {
     licenseAgree = 'yes'
 }
 
-buildDir = file('builtByGradle')
+allprojects {
+    ext {
+        buildPrefix = 'builtByGradle'
+    }
+}
+
+buildDir = file("${buildPrefix}/root")
 
 subprojects {
 
@@ -18,22 +24,29 @@ subprojects {
 
     // put all the build artifacts in subfolders of the root "build" folder
 //    buildDir = new File(rootProject.buildDir, it.path.replace(":", "_").substring(1))
-    buildDir = new File(rootProject.buildDir, it.path.replace(":", "_").substring(1))
+    buildDir = new File(file("${rootProject.projectDir}/${buildPrefix}"), it.path.replace(":", "_").substring(1))
 
     ext {
-        distDir = file("${buildDir}/${cbp['build.dist']}")
-        repoDir = file("${buildDir}/${cbp['build.dist.repo']}")
-        globalLibDir = file("${rootProject.projectDir}/lib")
+        distDir = file("${rootProject.projectDir}/${buildPrefix}/distribution")
+        repoDir = file("${distDir}/repo")
+        samplesDir = file("${distDir}/samples")
+        templatesDir = file("${distDir}/templates")
+        repoLibDir = file("${distDir}/lib")
+        repoBinDir = file("${distDir}/bin")
     }
 
     version= cbp.'ceylon.version'
 
     repositories {
         flatDir {
-            dirs globalLibDir
+            dirs "${rootProject.projectDir}/lib"
         }
+        jcenter()
         mavenCentral()
     }
 }
 
+task dist {
+    dependsOn ':dist:publishInternal'
+}
 

--- a/buildSrc/src/main/groovy/CeylonCommonBuildProperties.groovy
+++ b/buildSrc/src/main/groovy/CeylonCommonBuildProperties.groovy
@@ -19,17 +19,7 @@ class CeylonCommonBuildProperties implements Plugin<Project> {
                      'sun.boot.class.path' : ''
                 ])
 
-//            if(ext.cbp == null) {
-//                throw new GradleException ('ext.cbp is not defined. Did you load common-build.properties correctly?')
-//            }
-
-
             ext.requiresCBP = { String propName -> project.extensions.cbp.requires(propName) }
-//
-//                if(cbp."${propName}" == null) {
-//                    throw new GradleException ("${propName} is not defined in common-build.properties")
-//                }
-//            }
         }
 
     }

--- a/cli/cli.gradle
+++ b/cli/cli.gradle
@@ -24,8 +24,14 @@ task startScripts( type : Copy ) {
 task publishScripts( type : Copy ) {
     group 'Distribution'
     description 'Copies scripts to distribution area'
-    into repoDir
-    from startScripts
+    into repoBinDir
+    from startScripts, {
+        exclude 'ceylon'
+    }
+    from startScripts, {
+        include 'ceylon'
+        fileMode 0755
+    }
 }
 
 assemble {
@@ -34,4 +40,8 @@ assemble {
 
 publishInternal {
     dependsOn publishScripts
+}
+
+['common','cmr','model'].each {
+    publishInternal.dependsOn ":${it}:publishInternal"
 }

--- a/cmr/cmr.gradle
+++ b/cmr/cmr.gradle
@@ -38,3 +38,8 @@ sourceSets {
         }
     }
 }
+
+
+['common','model','cmr-aether','cmr-webdav','cmr-js'].each {
+    publishInternal.dependsOn ":${it}:publishInternal"
+}

--- a/compiler-java/compilerjava.gradle
+++ b/compiler-java/compilerjava.gradle
@@ -1,10 +1,13 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 ext {
     ceylonModuleName = 'compiler'
     ceylonTestDisabled = true
+    ceylonModuleVariant = 'java'
 }
 
 apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"
-
+requiresCBP 'module.ceylon.bootstrap.version'
 
 dependencies {
     compile project(':common')
@@ -27,9 +30,6 @@ sourceSets {
         java {
             srcDir 'langtools/src/share/classes'
             include "com/redhat/**"
-//            include "com/redhat/ceylon/langtools/tools/javac/**"
-//            include "com/redhat/ceylon/langtools/source/**"
-//            include "com/redhat/ceylon/javax/**"
             exclude "**/Java7Checker.java"
             exclude "com/redhat/ceylon/ant/**"
             exclude "com/redhat/ceylon/launcher/**"
@@ -52,7 +52,9 @@ sourceSets {
             srcDirs = []
         }
         resources {
+            srcDirs = [ 'src',"${project(':common').projectDir}/src"]
             include "com/redhat/ceylon/ant/antlib.xml"
+            include "com/redhat/ceylon/common/config/messages.properties"
         }
     }
 
@@ -113,6 +115,7 @@ compileJdk6StubsJava {
     dependsOn compileJava
 }
 
+
 assemble {
     dependsOn compileJdk6StubsJava
 }
@@ -123,6 +126,7 @@ jar {
     exclude "com/redhat/ceylon/common/**"
     exclude "com/redhat/ceylon/launcher/**"
 }
+
 
 task antJar ( type : Jar ) {
     group 'Build'
@@ -135,6 +139,7 @@ task antJar ( type : Jar ) {
         include "com/redhat/ceylon/ant/**"
         include "com/redhat/ceylon/common/**"
         include "com/redhat/ceylon/launcher/**"
+        exclude "com/redhat/ceylon/common/log/*.class"
     }
     from sourceSets.antTask.output.resourcesDir
 }
@@ -150,16 +155,18 @@ task bootstrapJar( type : Jar ) {
         include "com/redhat/ceylon/launcher/CeylonClassLoader.class"
         include "com/redhat/ceylon/launcher/LauncherUtil.class"
     }
-    // TODO: Merge manifests?
-    from sourceSets.main.output.resourcesDir, {
-        include "META-INF/MANIFEST.MF"
+
+    manifest {
+        attributes 'Manifest-Version': 1.0,
+            'Main-Class': 'com.redhat.ceylon.launcher.Bootstrap'
     }
 }
+
 
 task bootstrapModule( type : Jar ) {
     ext {
         bmSymbolicName = 'com.redhat.ceylon.bootstrap'
-        bmVersionName = cbp."module.${bmSymbolicName}.version"
+        bmVersionName = cbp."module.ceylon.bootstrap.version"
     }
     manifest {
         attributes 'Bundle-SymbolicName': bmSymbolicName,
@@ -185,29 +192,50 @@ sha1 {
     dependsOn bootstrapModule
 }
 
-//"""
-//    <target name="build" depends="compiler.jar,ant.jar,bootstrap.jar,bootstrap.module">
-//        <mkdir dir="${build.dist}" />
-//        <mkdir dir="${build.bin}" />
-//        <mkdir dir="${build.ceylon.cars}" />
-//
-//        <copy todir="${build.bin}">
-//            <fileset dir="${basedir}/bin">
-//            </fileset>
-//            <filterset>
-//                <filter token="ceylon-version" value="${ceylon.version}"/>
-//            </filterset>
-//        </copy>
-//        <chmod perm="0755">
-//            <fileset dir="${build.bin}">
-//                <include name="ceylon" />
-//            </fileset>
-//        </chmod>
-//    </target>
-//"""
+task publishBootstrapModule( type : Copy ) {
+    group 'Distribution'
+    description 'Copies binary artifacts to distribution area'
 
+    from sha1, {
+        include "**/ceylon.bootstrap-${bootstrapModule.ext.bmVersionName}.jar.*"
+    }
+
+    from bootstrapModule
+    into "${repoDir}/${cbp.'ceylon.bootstrap.dir'}"
+}
 
 publishJar {
     from bootstrapModule
 }
 
+task publishJvmCompilerJars ( type : Copy ) {
+    group "Distribution"
+    description "Copy bootstrap & Ant jars to distribution area"
+    from bootstrapJar
+    from antJar
+    into repoLibDir
+}
+
+publishInternal {
+    dependsOn publishJvmCompilerJars
+    dependsOn publishBootstrapModule
+}
+
+
+//"""
+//    <target name="compiler.jar" depends="compiler.classes">
+//        <mkdir dir="${build.dist.repo}/${ceylon.compiler.dir}" />
+//        <mkdir dir="${build.bin}" />
+
+//        <jar destfile="${build.dist.repo}/${ceylon.compiler.jar}">
+//        <jar destfile="${build.dist.repo}/${ceylon.bootstrap.jar}">
+
+//ceylon.bootstrap.dir=ceylon/bootstrap/${module.ceylon.bootstrap.version}
+//ceylon.bootstrap.jar=${ceylon.bootstrap.dir}/ceylon.bootstrap-${module.ceylon.bootstrap.version}.jar
+//ceylon.bootstrap.lib=${ceylon.repo.dir}/${ceylon.bootstrap.jar}
+
+//ceylon.compiler.dir=com/redhat/ceylon/compiler/java/${module.com.redhat.ceylon.compiler.version}
+//ceylon.compiler.jar=${ceylon.compiler.dir}/com.redhat.ceylon.compiler.java-${module.com.redhat.ceylon.compiler.version}.jar
+//ceylon.compiler.lib=${ceylon.repo.dir}/${ceylon.compiler.jar}
+
+//"""

--- a/compiler-js/compilerjs.gradle
+++ b/compiler-js/compilerjs.gradle
@@ -98,3 +98,8 @@ sha1 {
 assemble {
     dependsOn buildLanguageModule
 }
+
+['common','cli','cmr','typechecker','model'].each {
+    publishInternal.dependsOn ":${it}:publishInternal"
+}
+

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -1,11 +1,13 @@
 apply plugin : LifecycleBasePlugin
 
 task setupRepo {
+    group 'Distribution'
     dependsOn ':runtime:setupRepo'
     dependsOn ':runtime:publishInternal'
 }
 
 task installCompiler {
+    group 'Distribution'
     dependsOn ':common:publishInternal'
     dependsOn ':cli:publishInternal'
     dependsOn ':langtools-classfile:publishInternal'
@@ -13,27 +15,112 @@ task installCompiler {
     dependsOn ':cmr:publishInternal'
     dependsOn ':typechecker:publishInternal'
     dependsOn ':compiler-java:publishInternal'
+    mustRunAfter setupRepo
+}
+
+task installRuntime {
+    group 'Distribution'
+    dependsOn ':common:publishInternal'
+    dependsOn ':model:publishInternal'
+    dependsOn ':cmr:publishInternal'
+    dependsOn ':tool-provider:publishInternal'
+    dependsOn ':language:publishInternal'
+    dependsOn ':java-main:publishInternal'
+    mustRunAfter setupRepo
 }
 
 task installJS {
-
+    group 'Distribution'
     dependsOn ':common:publishInternal'
     dependsOn ':cli:publishInternal'
     dependsOn ':model:publishInternal'
     dependsOn ':cmr:publishInternal'
     dependsOn ':typechecker:publishInternal'
     dependsOn ':compiler-js:publishInternal'
-
+    mustRunAfter setupRepo
 }
 
-build {
+task copyCompilerBinaries {
+
+    group 'Distribution'
+    description "Copies scripts and completions scripts to distribution bin area"
+    dependsOn ':cli:startScripts'
+}
+
+
+task copySupportFiles( type : Copy) {
+    group 'Distribution'
+    description "Copy licenses, samples, templates etc."
+    into distDir
+
+    from 'samples', {
+        include "helloworld/**"
+        include "no-module/**"
+        include "with-module/**"
+        include "interop-java/**"
+        include "plugin/**"
+        into 'samples'
+    }
+
+    from 'templates', {
+        into 'templates'
+    }
+
+    from 'contrib', {
+        into 'contrib'
+    }
+
+    from 'bin', {
+        into 'bin'
+    }
+
+    from rootProject.projectDir, {
+        include "LICENSE-ASL"
+        include "LICENSE-LGPL"
+        include "LICENSE-GPL-CP"
+        include "README.md"
+    }
+
+    from projectDir, {
+        include 'NOTICE'
+    }
+}
+
+task publishInternal {
+    group 'Distribution'
+    description "Lifecycle task to cooridnate all internal publish tasks"
     dependsOn setupRepo, installCompiler, installJS
+    dependsOn copyCompilerBinaries, copySupportFiles
+    dependsOn installRuntime
+    // addModuleDescriptors
+    // generateBuildId
 }
 
-//<target name="install-all"
-//depends="setup-repo, install-compiler, install-js, copy-compiler-binaries,
-//copy-samples, copy-templates, copy-contrib, copy-jvm-compiler-libraries,
-//copy-licenses, install-runtime,
-//add-module-descriptors, generate-buildid"
-//description="Generates all binaries and copies them to the distribution folder">
-//</target>
+
+
+// dist: publish,ide-quick
+// publish: clean-projects,install-all,copy-dist-bin,publish-quick
+// install-all: setup-repo, install-compiler, install-js, copy-compiler-binaries
+//               copy-samples, copy-templates, copy-contrib, copy-jvm-compiler-libraries,
+//               copy-licenses, install-runtime,
+//               add-module-descriptors, generate-buildid
+// ide-quick:
+// copy-dist-bin: DONE
+// publish-quick: DONE
+// setup-repo:
+// install-compiler:
+// install-js:
+// copy-compiler-binaries:
+// install-runtime: install-common,install-model,install-cmr,install-tool-provider,install-language,
+//                  install-java-main,install-runtime-nodeps"
+
+
+
+task cleanRepo ( type : Delete ) {
+    group "clean"
+    description "Cleans the distribution area"
+    delete repoBinDir
+    delete repoLibDir
+    delete samplesDir
+    delete repoDir
+}

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -17,17 +17,27 @@ Ant & Gradle builds.
 [source,xml]
 ----
 <target name="install-all"
-    depends="setup-repo, install-compiler, install-js, copy-compiler-binaries, <!-- 1 --> <!-- 2 -->
-             copy-samples, copy-templates, copy-contrib, copy-jvm-compiler-libraries,
-             copy-licenses, install-runtime,
+    depends="setup-repo, install-compiler, install-js, <!-- 1 --> <!-- 2 -->
+             copy-compiler-binaries, <!-- 3 -->
+             copy-samples, copy-templates, copy-contrib, copy-licenses, <!-- 4 -->
+             copy-jvm-compiler-libraries, <!-- 5 -->
+              install-runtime, <!-- 6 -->
              add-module-descriptors, generate-buildid"
     description="Generates all binaries and copies them to the distribution folder">
 </target>
 ----
 <1> `setup-repo` handled `:runtime:setupRepo`
-<2> `install-compiler` handled by `publishInternal` task in `common`, `cli`, `;angtools-classfile`,
+<2> `install-compiler` handled by `publishInternal` task in `common`, `cli`, `langtools-classfile`,
   `model`, `cmr` ...
+<3> `copy-compiler-binaries` handled by `:cli:startScripts` & `:dist:copyCompilerBinaries`
+<4> `copy-licenses`, `copy-samples`, `copy-templates` & `copy-contrib` handled by `:dist:copySupportFiles`
+<5> `copy-jvm-compiler-libraries` handled by `:compiler-java:publishInternal`.
+<6> `install-runtime` handled by `:distinstallRuntime`.
 
+In addition the `copy-dist-bin` Ant task is handled by
+
+.TODO
+* `ceylon-completion.bash` is copied twice - once in `copyContrib` and once in `copyCompilerBinaries`
 
 === Commons
 
@@ -50,6 +60,7 @@ Needed a special `sourceSet` layout.
 As all of the four Ant `javac` tasks ended up in a single JAR and used the same compilation options,
  I think putting them into a single compilation task was the way to go.
 
+In order to rename `_version_` when copying XML files, the use of `eachFile` was necessary.
 
 .TODO
 * What about those `pom.xml` files that are dotted over the place?
@@ -173,6 +184,11 @@ knows how to take care of them.
 .TODO
 * Do we need to set the compiler flag `-XDignore.symbol.file` ?
 
+=== Java-main
+
+.TODO
+* Do we need to set the compiler flag `-XDignore.symbol.file` ?
+
 == Custom build code in buildSrc
 
 A `buildSrc` folder has been added to help with some of the delicate and less common feastures of this build.
@@ -244,6 +260,4 @@ Gradle lifecycle tasks to appropriate ones in the Ant build.
 | `language` | Disabled (imported Ant tasks)
 | `tool-provider | Disabled (requires updates to Gradle script)
 | `typechecker` | Disabled (requires updates to Gradle script)
-
-
 |===

--- a/gradle/java-for-modules.gradle
+++ b/gradle/java-for-modules.gradle
@@ -1,4 +1,5 @@
 import org.apache.tools.ant.filters.EscapeUnicode
+import org.apache.tools.ant.filters.ReplaceTokens
 
 // Shorten the recipes required in Gradle scripts byt moving
 // a lot of the common code here.
@@ -33,10 +34,16 @@ requiresCBP 'compile.java.target'
 requiresCBP 'compile.java.source'
 
 ext {
-    bundleSymbolicName = 'com.redhat.ceylon.' + ceylonModuleName
+    bundleVariant = ext.properties.containsKey('ceylonModuleVariant') ? ".${ceylonModuleVariant}" : ''
+    bundleSymbolicName = 'com.redhat.ceylon.' + ceylonModuleName + bundleVariant
     bundleVersionName = cbp."module.com.redhat.ceylon.${ceylonModuleName}.version"
     archivePublishDir = "${repoDir}/" +  cbp."ceylon.${ceylonPublishModuleName}.dir"
 }
+
+//com.read.ceylon.compiler-1.2.3,jar
+//archiveName = "${bundleSymbolicName}-${bundleVersionName}.jar"
+//ceylon.compiler.jar=${ceylon.compiler.dir}/com.redhat.ceylon.compiler.java-${module.com.redhat.ceylon.compiler.version}.jar
+//ceylon.compiler.dir=com/redhat/ceylon/compiler/java/${module.com.redhat.ceylon.compiler.version}
 
 if(!ext.properties.containsKey('ceylonSourceLayout')) {
         ext.ceylonSourceLayout = true
@@ -62,6 +69,7 @@ compileJava {
 
 assemble {
     dependsOn 'sha1'
+    dependsOn 'copyPluginFiles'
 }
 
 processResources {
@@ -87,6 +95,7 @@ if (ext.ceylonSourceLayout) {
         test {
             java {
                 srcDirs = ['test/src']
+                include '**/*.java'
             }
             resources {
                 srcDirs = ['test/src']
@@ -128,7 +137,7 @@ task publishJar( type : Copy ) {
     description 'Copies binary artifacts to distribution area'
 
     from sha1, {
-        include '**/*.jar.*'
+        include "**/${bundleSymbolicName}-${bundleVersionName}.jar.*"
     }
 
     from jar
@@ -147,8 +156,30 @@ task publishSource( type : Copy ) {
     into archivePublishDir
 }
 
+task copyPluginFiles( type : Copy ) {
+    group "build"
+    description 'Copies plugin files with correct version information'
+    from 'bin', {
+        include 'ceylon-*.plugin'
+    }
+    into "${buildDir}/bin"
+
+    filter ReplaceTokens, tokens : ['ceylon-version': version ]
+}
+
+task publishPluginFiles( type : Copy ) {
+    group "Distribution"
+    description "Copies bin directory to distribution area"
+    from "${buildDir}/bin", {
+        include 'ceylon-*.plugin'
+    }
+    into repoBinDir
+    dependsOn copyPluginFiles
+}
+
 task publishInternal {
     dependsOn 'publishJar','publishSource'
+    dependsOn publishPluginFiles
 }
 
 task cleanRepo ( type : Delete ) {
@@ -167,4 +198,10 @@ if(ext.properties.containsKey('ceylonTestDisabled')) {
     test.enabled = false
     testClasses.enabled = false
     compileTestJava.enabled = false
+}
+
+afterEvaluate {
+    tasks.withType(JavaCompile) { t ->
+        t.options.compilerArgs ['-Xlint:-options']
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/java-main/javamain.gradle
+++ b/java-main/javamain.gradle
@@ -14,3 +14,7 @@ dependencies {
 
 // TODO: Can be removed if language build is pure Gradle
 compileJava.dependsOn ':language:assemble'
+
+['common','cmr','language'].each {
+    publishInternal.dependsOn ":${it}:publishInternal"
+}

--- a/java-main/javamain.gradle
+++ b/java-main/javamain.gradle
@@ -1,0 +1,16 @@
+ext {
+    ceylonModuleName = 'java.main'
+}
+
+apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"
+
+dependencies {
+    compile project(':model')
+    compile project(':cmr')
+    compile project(':common')
+    compile project(':langtools-classfile')
+    compile project( path : ':language', configuration : 'antOutput' )
+}
+
+// TODO: Can be removed if language build is pure Gradle
+compileJava.dependsOn ':language:assemble'

--- a/language/ant-language.gradle
+++ b/language/ant-language.gradle
@@ -1,0 +1,20 @@
+apply plugin : LifecycleBasePlugin
+ant.properties.'ceylon.dist.dir' = project.properties.ceylonDistDir
+ant.properties.'ceylon.repo.dir' = project.properties.ceylonRepoDir
+ant.properties.'build.dir' = project.properties.ceylonBuildDir
+ant.importBuild('build.xml') { "ant${it.capitalize()}".toString() }
+clean.dependsOn antClean
+check.dependsOn antTest
+assemble.dependsOn antBuild
+
+// TODO: Need to fix this when getting tests to work.
+antTest.enabled = false
+
+// TODO: Need to fix this when getting tests to work.
+tasks.'antCompile.tests.java.quick'.enabled = false
+tasks.'antCompile.tests.java'.enabled = false
+tasks.'antTest.java.quick'.enabled = false
+tasks.'antTest-quick'.enabled = false
+tasks.'antTest.java'.enabled = false
+tasks.'antTest.js'.enabled = false
+tasks.'antTest.js.quick'.enabled = false

--- a/language/language.gradle
+++ b/language/language.gradle
@@ -2,15 +2,42 @@ ext {
     ceylonModuleName = 'language'
 }
 
-apply from : "${rootProject.projectDir}/gradle/use-ant-build.gradle"
+apply plugin : LifecycleBasePlugin
+apply plugin : CeylonCommonBuildProperties
 
-antBuild.dependsOn ':compiler-java:assemble'
+configurations {
+    antOutput
+}
 
-// TODO: Need to fix this when getting tests to work.
-tasks.'antCompile.tests.java.quick'.enabled = false
-tasks.'antCompile.tests.java'.enabled = false
-tasks.'antTest.java.quick'.enabled = false
-tasks.'antTest-quick'.enabled = false
-tasks.'antTest.java'.enabled = false
-tasks.'antTest.js'.enabled = false
-tasks.'antTest.js.quick'.enabled = false
+dependencies {
+    antOutput fileTree("${buildDir}/dist") {
+        include "**/*.jar"
+        include "**/*.car"
+    }
+}
+
+task invokeAntBuild( type : GradleBuild ) {
+    dir = projectDir
+    buildFile = file('ant-language.gradle')
+    tasks = ['antPublish']
+    startParameter.projectProperties+= [
+        ceylonDistDir  : distDir,
+        ceylonRepoDir  : repoDir,
+        ceylonLibDir   : repoLibDir,
+        ceylonBuildDir : buildDir
+    ]
+
+    // TODO: There are too many of these manual dependencies being listed... feels like duct-tape and string.
+    dependsOn ':compiler-java:assemble', ':compiler-java:publishJvmCompilerJars', ':runtime:setupRepo'
+}
+
+assemble.dependsOn invokeAntBuild
+
+task publishInternal {
+    dependsOn invokeAntBuild
+}
+
+['common','cli','model','cmr','compiler-java','langtools-classfile','typechecker','compiler-js'].each {
+    publishInternal.dependsOn ":${it}:publishInternal"
+    invokeAntBuild.dependsOn ":${it}:publishInternal"
+}

--- a/model/model.gradle
+++ b/model/model.gradle
@@ -9,3 +9,7 @@ dependencies {
     compile project(':langtools-classfile')
 }
 
+['common','langtools-classfile'].each {
+    publishInternal.dependsOn ":${it}:publishInternal"
+}
+

--- a/runtime/runtime.gradle
+++ b/runtime/runtime.gradle
@@ -60,8 +60,10 @@ task setupRepo( type : Copy ) {
     into repoDir
     from 'dist/repo', {
         include "**/*.xml"
-        filter { it.replaceAll( '_version_',version) }
-        filter ReplaceTokens, tokens : [ 'ceylon-version' : version ]
+        eachFile { fcd ->
+            fcd.path = fcd.path.replace('_version_',version)
+            fcd.filter ReplaceTokens, tokens : [ 'ceylon-version' : version ]
+        }
     }
     from 'dist/repo', {
         include '**/*.jar'
@@ -70,6 +72,10 @@ task setupRepo( type : Copy ) {
     doFirst {
         logger.info "TODO: Copying hardcoded JARs might be better dealt with using Gradle's dependency management"
     }
+}
+
+['common','cmr','language','tool-provider','java-main'].each {
+    publishInternal.dependsOn ":${it}:publishInternal"
 }
 
 //

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,3 +46,6 @@ project(':module-loader').buildFileName = 'moduleloader.gradle'
 
 include 'tool-provider'
 project(':tool-provider').buildFileName = 'toolprovider.gradle'
+
+include 'java-main'
+project(':java-main').buildFileName = 'javamain.gradle'

--- a/tool-provider/toolprovider.gradle
+++ b/tool-provider/toolprovider.gradle
@@ -30,3 +30,9 @@ sourceSets {
 }
 
 // TODO: Do we need to set compiler flag: <compilerarg value="-XDignore.symbol.file" /> ?
+
+
+['common','cli','model','module-loader','cmr','language'].each {
+    publishInternal.dependsOn ":${it}:publishInternal"
+}
+

--- a/typechecker/typechecker.gradle
+++ b/typechecker/typechecker.gradle
@@ -82,3 +82,7 @@ sourceZip {
         include '**/*.java'
     }
 }
+
+['common','cli','cmr','model'].each {
+    publishInternal.dependsOn ":${it}:publishInternal"
+}


### PR DESCRIPTION
Most of the PR focuses around fixing the dependency that the build had on the native Ant build having been run first. 

_Key fixes_:
- `dist` task has been added to root project
- Fixed publishing in all subproejcts
- Add `java-main` which got missed in the first round of restructuring
- `language` build now uses a `GradleBuild` task to defer evalutaion of dependencies that is required for calling the Ant build
- Fixed the naming of JAR artifacts in `compiler-java` as well as some missing files from the JARs.
- Added support for automatic coying `*.plugin` files in subprojects.

_Outstanding issues_:
- module.xml files
- OSGI
