### PR TITLE
Support narrowing dynamic types to subtypes

### DIFF
--- a/compiler-js/src/test/ceylon/dyns/interfaces.ceylon
+++ b/compiler-js/src/test/ceylon/dyns/interfaces.ceylon
@@ -63,4 +63,38 @@ void testDynamicInterfaces() {
   }
   check((test616<JsStr>(true) of Object) is JsStr, "#616.1");
   check((test616<JsStr>(false) of Object) is JsStr, "#616.2");
+  
+  testNarrowDynamicInterfaces();
+}
+
+dynamic HasA {
+    shared formal String a;
+}
+dynamic HasAB satisfies HasA {
+    shared formal String b;
+}
+dynamic HasABC satisfies HasAB {
+    shared formal String c;
+}
+dynamic OtherHasABC {
+    shared formal String a;
+    shared formal String b;
+    shared formal String c;
+}
+
+void testNarrowDynamicInterfaces() {
+    HasA abc;
+    dynamic { abc = dynamic [ a = "a"; b = "b"; c = "c"; ]; }
+    check(abc is HasA, "object has its static type");
+    check(abc is HasAB, "narrow type");
+    check(abc is HasABC, "narrow type 2");
+    check(abc is HasA, "object still has its static type");
+    check(!abc is OtherHasABC, "don't narrow to unrelated type");
+    check(abc is HasA, "object still has its static type 2");
+    HasA ab;
+    dynamic { ab = dynamic [ a = "a"; b = "b"; ]; }
+    check(ab is HasA, "second object has its static type");
+    check(ab is HasAB, "narrow type 3");
+    check(!ab is HasABC, "don't narrow to inappropriate type");
+    check(!ab is OtherHasABC, "don't narrow to inappropriate and unrelated type");
 }

--- a/language/runtime-js/is-op.js
+++ b/language/runtime-js/is-op.js
@@ -184,6 +184,26 @@ function is$(obj,type,containers){
         }
       }
       return true;
+    } else {
+      // try narrowing to subtype if both current and requested type are dynamic
+      var objtype = obj.getT$all()[obj.getT$name()];
+      if (objtype && objtype.dynmem$ && type.t.dynmem$ && extendsType(type, {t:objtype}, true)) {
+        var _getT$all = obj.getT$all;
+        var _$$ = obj.$$;
+        try {
+          // undress the object
+          obj.getT$all = undefined;
+          obj.$$ = undefined;
+          // try to redress it with subtype
+          dre$$(obj, type);
+          return true;
+        } catch (e) {
+          // redress with old info
+          obj.getT$all = _getT$all;
+          obj.$$ = _$$;
+          return false;
+        }
+      }
     }
   }
   return false;


### PR DESCRIPTION
`is$` will now attempt to redress an object with the checked type if that is a subtype of the already dressed type of the object and if both those types are dynamic. Implements #6307.

(This isn’t ready for merging yet – I need to add some tests – but some manual tests suggests that the implementation is sound, and therefore ready for review :) @chochos does this look reasonable?)
