### PR TITLE
Restructuring Gradle Build #3 - Taking care of OSGI building

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,43 @@ subprojects {
 }
 
 task dist {
+    group "publish"
+    description "Creates the Ceylon distribution"
     dependsOn ':dist:publishInternal'
 }
+
+task clean ( type : Delete ) {
+    delete buildDir
+}
+
+task 'clean-all' {
+    group "ceylon cross project"
+    description "Cleans everything here and in linked projects"
+    dependsOn clean
+//    dependsOn 'clean-sdk'
+//    dependsOn 'clean-ide'
+}
+
+/*
+task 'clean-sdk' {
+    group "ceylon cross project"
+    description "Cleans the SDK"
+    dependsOn ':ceylon-sdk:clean'
+}
+
+task sdk {
+    group "ceylon cross project"
+    description 'Builds the SDK'
+    dependsOn ':ceylon-sdk:publishInternal'
+}
+
+//clean-sdk - calls ant clean in the ../ceylon-sdk folder
+//    sdk - calls ant publish ide-quick in the ../ceylon-sdk folder
+//clean-ide - calls ant clean in the ../ceylon-.formatter, ../ceylon.tool.converter.java2ceylon, ../ceylon-ide-common, ../ceylon-ide-eclipse and ../ceylon-ide-intellij folders
+//    eclipse - calls ant publish ide-quick in the ../ceylon-.formatter, ../ceylon.tool.converter.java2ceylon, ../ceylon-ide-common and ../ceylon-ide-eclipse folders
+//    intellij - calls ant publish ide-quick in the ../ceylon-.formatter, ../ceylon.tool.converter.java2ceylon, ../ceylon-ide-common and ../ceylon-ide-intellij folders
+
+*/
+
+
 

--- a/buildSrc/src/main/groovy/AbstractCeylonOsgiArchiveTaskExtension.groovy
+++ b/buildSrc/src/main/groovy/AbstractCeylonOsgiArchiveTaskExtension.groovy
@@ -80,8 +80,7 @@ abstract class AbstractCeylonOsgiArchiveTaskExtension {
     String getRequireBundle() {
         List<String> optRes = this.optionalResolution
         moduleContent.dependencies.module.findAll { module ->
-            !(excludedModuleNames.contains(module.@name.toString()) /*||
-                module.@name=='ceylon.language' && bundleSymbolicName == 'com.redhat.ceylon.model'*/)
+            !(excludedModuleNames.contains(module.@name.toString()))
         }.collect { module ->
             String attr = "${module.@name};bundle-version=${module.@slot}"
             if(module.@export == 'true') {

--- a/buildSrc/src/main/groovy/AbstractCeylonOsgiArchiveTaskExtension.groovy
+++ b/buildSrc/src/main/groovy/AbstractCeylonOsgiArchiveTaskExtension.groovy
@@ -1,0 +1,161 @@
+import groovy.util.slurpersupport.GPathResult
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.util.GradleVersion
+
+/**
+ * @author Schalk W. Cronjé
+ */
+abstract class AbstractCeylonOsgiArchiveTaskExtension {
+
+    abstract void configureManifestForTask()
+
+    /** Set to true if javax.lang.model.* needs to be imported
+     *
+     */
+    boolean importJavaxModel = false
+
+    /** Sets the location of the {@code module.xml} file in a lazy-evaluatable manner
+     *
+     * @param location Any location that can be resolve by Gradle's {@code project.file} method.
+     *
+     */
+    void setModuleLocation(def location) {
+        this.moduleLocation = location
+    }
+
+    /** Returns the location of the {@code module.xml} file
+     *
+     * @return
+     */
+    File getModuleLocation() {
+        if(this.moduleLocation == null) {
+            throw new GradleException('moduleLocation cannot be null')
+        }
+        archiveTask.project.file(this.moduleLocation)
+    }
+
+    /** Gets the {@code mpdule.xml} as traversable tree
+     *
+     * @return
+     */
+    GPathResult getModuleContent() {
+        new XmlSlurper().parse(getModuleLocation())
+    }
+
+    /** If module names matches any of these, then {@code resolution:=optional} will be added
+     * to a {@code Require-Bundle} irrespective of whether the module is marked optioonal or not
+     * @param moduleNames
+     */
+    void forceOptionalResolutionFor(String... moduleNames) {
+        optionalResolution.addAll(moduleNames as List)
+    }
+
+    /** Get list of excluded modules
+     *
+     * @return
+     */
+    List<String> getExcludedModuleNames() {
+        this.excludedModuleNames
+    }
+
+    /** Add addition modules to be excluded
+     *
+     * @param names
+     */
+    void excludedModuleNames(String... names) {
+        this.excludedModuleNames.addAll(names as List)
+    }
+
+    /** Override the existing list of excluded module names with a new list.
+     *
+     * @param newModuleNames
+     */
+    void setExcludedModuleNames(final List<String> newModuleNames) {
+        this.excludedModuleNames.clear()
+        this.excludedModuleNames.addAll(newModuleNames)
+    }
+
+    String getRequireBundle() {
+        List<String> optRes = this.optionalResolution
+        moduleContent.dependencies.module.findAll { module ->
+            !(excludedModuleNames.contains(module.@name.toString()) /*||
+                module.@name=='ceylon.language' && bundleSymbolicName == 'com.redhat.ceylon.model'*/)
+        }.collect { module ->
+            String attr = "${module.@name};bundle-version=${module.@slot}"
+            if(module.@export == 'true') {
+                attr+=";visibility:=reexport"
+            }
+            if(module.@optional== 'true' || optRes.contains(module.@name.toString()) ) {
+                attr+=";resolution:=optional"
+            }
+            attr
+        }.join(',')
+
+    }
+
+    protected AbstractCeylonOsgiArchiveTaskExtension(AbstractArchiveTask task) {
+        this.archiveTask = task
+    }
+
+    protected Map<String,String> getManifestInstructions(
+        final String osgiBundleVersion,
+        final String osgiBundleSymbolicName,
+        final String origBundleVersion,
+        final Map<String,String> osgiDynamicImports = [:]
+    ) {
+        Map<String,String> instructions = [
+            'Bundle-Version' :  osgiBundleVersion,
+            'Bundle-SymbolicName' : osgiBundleSymbolicName,
+            'Export-Package' : "!about.html, !licenses, !settings.xml, *;version=\"${origBundleVersion}\"",
+            '-nouses' : 'true',
+            'Gradle-Version' : GradleVersion.current().toString(),
+            'DSTAMP' : TimeStamp.DSTAMP,
+            'NOW' : TimeStamp.NOW,
+            'TODAY' : TimeStamp.TODAY,
+            'TSTAMP' : TimeStamp.TSTAMP
+        ]
+
+        if(osgiDynamicImports.size()) {
+            String packages = osgiDynamicImports.collect { k,v ->
+                k + ';bundle-version=' + v
+            }.join(',')
+            instructions+= [ 'DynamicImport-Package' : packages ]
+        }
+
+        if(importJavaxModel) {
+            instructions+= ['Import-Package' : 'javax.lang.model.*']
+        } else {
+            instructions+= ['-removeheaders' : 'Import-Package' ]
+        }
+
+        String requires = getRequireBundle()
+        if(!requires?.empty) {
+            instructions+= ['Require-Bundle' : requires]
+        }
+        instructions
+    }
+
+    protected AbstractArchiveTask getArchiveTask() {
+        this.archiveTask
+    }
+
+    private def moduleLocation
+    private List<String> optionalResolution = []
+    private List<String> excludedModuleNames = [
+        'java.base','java.compiler','java.logging',
+        'javax.xml','java.instrument',
+        'javax.jaxws','java.desktop',
+        'java.prefs','oracle.jdk.base',
+        'java.jdbc',
+        'javax.script',
+        'java.auth.kerberos',
+        'java.tls',
+        'java.management',
+        'irg.sl4j.simple'
+    ]
+
+    private final AbstractArchiveTask archiveTask
+
+}

--- a/buildSrc/src/main/groovy/CeylonAntlr.groovy
+++ b/buildSrc/src/main/groovy/CeylonAntlr.groovy
@@ -1,13 +1,8 @@
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.file.FileCollection
-import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 
 // This has been written because Gradle's Antlr plugin is broken. It is
@@ -47,7 +42,7 @@ class CeylonAntlr implements Plugin<Project> {
             Map<String,Set<String>> ret = [:]
             this.groups.each { String relPath, def inputFiles ->
                 ret[relPath] = project.files(inputFiles).files.collect { File f ->
-                    CeylonAntlr.relativeTo(f,project.projectDir)
+                    CeylonBuildUtil.relativeTo(f,project.projectDir)
                 } as Set
             }
             ret
@@ -60,7 +55,7 @@ class CeylonAntlr implements Plugin<Project> {
 
             antlrGroups.each { String relPath, Set<String> inputFiles ->
                 File out = new File(root,relPath)
-                String outPath = CeylonAntlr.relativeTo(out,project.projectDir)
+                String outPath = CeylonBuildUtil.relativeTo(out,project.projectDir)
                 out.mkdirs()
                 project.javaexec {
                     main 'org.antlr.Tool'
@@ -76,9 +71,6 @@ class CeylonAntlr implements Plugin<Project> {
 
     }
 
-    static String relativeTo(final File thisPath,final File toThatPath) {
-        toThatPath.toPath().relativize( thisPath.toPath() ).toFile().toString()
-    }
 }
 
 

--- a/buildSrc/src/main/groovy/CeylonBuildModuleXml.groovy
+++ b/buildSrc/src/main/groovy/CeylonBuildModuleXml.groovy
@@ -1,0 +1,55 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+import org.apache.tools.ant.filters.ReplaceTokens
+
+class CeylonBuildModuleXml extends DefaultTask {
+    String version = project.version
+
+    CeylonBuildModuleXml() {
+        super()
+        group = 'build'
+        description = 'Creates a module.xml from a template file'
+    }
+
+    @InputFile
+    File getSourceModule() {
+        project.file(this.sourceModule)
+    }
+
+    void setSourceModule(Object f) {
+        this.sourceModule = f
+    }
+
+    File getDestinationDir() {
+        project.file(this.destinationDir)
+    }
+
+    void setDestinationDir(Object dest) {
+        this.destinationDir = dest
+    }
+
+    @OutputFile
+    File getDestinationFile() {
+        if(this.destinationDir == null) {
+            throw new GradleException('Destination directory has not been set')
+        }
+        new File(getDestinationDir(),'module.xml')
+    }
+
+    @TaskAction
+    void exec() {
+        project.copy {
+            from getSourceModule()
+            into getDestinationDir()
+            rename '.+','module.xml'
+            filter ReplaceTokens, tokens : [ 'ceylon-version' : this.version ]
+        }
+    }
+
+    private Object sourceModule
+    private Object destinationDir = { "${project.buildDir}/ceylon-module" }
+}

--- a/buildSrc/src/main/groovy/CeylonBuildOsgiPlugin.groovy
+++ b/buildSrc/src/main/groovy/CeylonBuildOsgiPlugin.groovy
@@ -1,0 +1,60 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.jvm.tasks.Jar
+
+/**
+ * @author Schalk W. Cronjé
+ */
+class CeylonBuildOsgiPlugin implements Plugin<Project> {
+
+    static final String EXTENSION_NAME = 'ceylon'
+
+    static void addOsgiTaskExtension(AbstractArchiveTask archiveTask) {
+        archiveTask.extensions.create(EXTENSION_NAME, CeylonOsgiArchiveTaskExtension, archiveTask)
+        archiveTask.doFirst {
+            CeylonBuildOsgiPlugin.configureManifest(archiveTask)
+        }
+    }
+
+    static void addOsgiArchiveMethod(AbstractArchiveTask archiveTask) {
+        archiveTask.ext.setAsOsgiArchive = {
+            archiveTask.manifest = archiveTask.project.osgiManifest ()
+            archiveTask.manifest.classesDir = archiveTask.project.sourceSets.main.output.classesDir
+            archiveTask.manifest.classpath = archiveTask.project.configurations.getByName("runtime")
+            addOsgiTaskExtension(archiveTask)
+        }
+    }
+
+    static void configureManifest(Jar task) {
+        CeylonOsgiArchiveTaskExtension metadata = task.extensions.getByName(EXTENSION_NAME)
+        task.manifest.name = metadata.bundleSymbolicName
+        task.manifest {
+            metadata.manifestInstructions.each { k,v ->
+                instructionReplace k,v
+            }
+        }
+    }
+
+    void apply(Project project) {
+
+        project.with {
+            apply plugin : 'osgi'
+
+            tasks.withType(Jar) {  task ->
+                if(task.name != 'jar') {
+                    CeylonBuildOsgiPlugin.addOsgiArchiveMethod(task)
+                } else {
+                    CeylonBuildOsgiPlugin.addOsgiTaskExtension(task)
+                }
+            }
+            tasks.whenTaskAdded { task ->
+                if(task instanceof Jar) {
+                    CeylonBuildOsgiPlugin.addOsgiArchiveMethod(task)
+                }
+            }
+
+            tasks.create 'moduleXml', CeylonBuildModuleXml
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/CeylonBuildUtil.groovy
+++ b/buildSrc/src/main/groovy/CeylonBuildUtil.groovy
@@ -1,0 +1,8 @@
+/**
+ * @author Schalk W. Cronjé
+ */
+class CeylonBuildUtil {
+    static String relativeTo(final File thisPath,final File toThatPath) {
+        toThatPath.toPath().relativize( thisPath.toPath() ).toFile().toString()
+    }
+}

--- a/buildSrc/src/main/groovy/CeylonOsgiArchiveTAskExtension.groovy
+++ b/buildSrc/src/main/groovy/CeylonOsgiArchiveTAskExtension.groovy
@@ -1,6 +1,7 @@
 import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.util.GradleVersion
 
 /** This extension will be added to each Archive task if
@@ -8,10 +9,10 @@ import org.gradle.util.GradleVersion
  * configuration (the latter depends on it being added by the {@code CeylonOsgi}
  * plugin).
  */
-class CeylonOsgiArchiveTaskExtension {
+class CeylonOsgiArchiveTaskExtension extends AbstractCeylonOsgiArchiveTaskExtension {
 
     CeylonOsgiArchiveTaskExtension( AbstractArchiveTask task ) {
-        this.archiveTask = task
+        super(task)
     }
 
     CeylonOsgiArchiveTaskExtension call( Closure cfg ) {
@@ -20,11 +21,6 @@ class CeylonOsgiArchiveTaskExtension {
         config()
         this
     }
-
-    /** Set to true if javax.lang.model.* needs to be imported
-     *
-     */
-    boolean importJavaxModel = false
 
     /** Set the symbolic name for this bundle.
      * Affects {@code Bundle-SymbolicName}
@@ -44,10 +40,6 @@ class CeylonOsgiArchiveTaskExtension {
         this.bundleVersion ?: exportedBundleVersion
     }
 
-//    void bundleVersion(final String bv) {
-//        this.bundleVersion = bv
-//    }
-
     /** Sets an OSGI bundle version.
      * Affects {@code Bundle-Version}
      *
@@ -55,39 +47,6 @@ class CeylonOsgiArchiveTaskExtension {
      */
     void setBundleVersion(final String bv) {
         this.bundleVersion = bv
-    }
-
-    /** Get list of excluded modules
-     *
-     * @return
-     */
-    List<String> getExcludedModuleNames() {
-        this.excludedModuleNames
-    }
-
-    /** Add addition modules to be excluded
-     *
-     * @param names
-     */
-    void excludedModuleNames(String... names) {
-        this.excludedModuleNames.addAll(names as List)
-    }
-
-    /** Override the existing list of excluded module names with a new list.
-     *
-     * @param newModuleNames
-     */
-    void setExcludedModuleNames(final List<String> newModuleNames) {
-        this.excludedModuleNames.clear()
-        this.excludedModuleNames.addAll(newModuleNames)
-    }
-
-    /** If module names matches any of these, then {@code resolution:=optional} will be added
-     * to a {@code Require-Bundle} irrespective of whether the module is marked optioonal or not
-     * @param moduleNames
-     */
-    void forceOptionalResolutionFor(String... moduleNames) {
-        optionalResolution.addAll(moduleNames as List)
     }
 
     /** Add packages that needs to be dynamically imported.
@@ -103,104 +62,25 @@ class CeylonOsgiArchiveTaskExtension {
      * @return
      */
     Map<String,String> getManifestInstructions() {
-        Map<String,String> instructions = [
-            'Bundle-Version' :  getBundleVersion(),
-            'Bundle-SymbolicName' : this.bundleSymbolicName,
-            'Export-Package' : "!about.html, !licenses, !settings.xml, *;version=\"${this.exportedBundleVersion}\"",
-            '-nouses' : 'true',
-            'Gradle-Version' : GradleVersion.current().toString(),
-            'DSTAMP' : TimeStamp.DSTAMP,
-            'NOW' : TimeStamp.NOW,
-            'TODAY' : TimeStamp.TODAY,
-            'TSTAMP' : TimeStamp.TSTAMP
-        ]
-
-        if(dynamicImports.size()) {
-            String packages = dynamicImports.collect { k,v ->
-                k + ';bundle-version=' + v
-            }.join(',')
-            instructions+= [ 'DynamicImport-Package' : packages ]
-        }
-
-        if(importJavaxModel) {
-            instructions+= ['Import-Package' : 'javax.lang.model.*']
-        } else {
-            instructions+= ['-removeheaders' : 'Import-Package' ]
-        }
-
-        String requires = getRequireBundle()
-        if(!requires?.empty) {
-            instructions+= ['Require-Bundle' : requires]
-        }
-        instructions
+        getManifestInstructions(
+            getBundleVersion(),
+            getBundleSymbolicName(),
+            getExportedBundleVersion(),
+            dynamicImports
+        )
     }
 
-    /** Sets the location of the {@code module.xml} file in a lazy-evaluatable manner
-     *
-     * @param location Any location that can be resolve by Gradle's {@code project.file} method.
-     *
-     */
-    void setModuleLocation(def location) {
-        this.moduleLocation = location
-    }
-
-    /** Returns the location of the {@code module.xml} file
-     *
-     * @return
-     */
-    File getModuleLocation() {
-        if(this.moduleLocation == null) {
-            throw new GradleException('moduleLocation cannot be null')
-        }
-        archiveTask.project.file(this.moduleLocation)
-    }
-
-    /** Gets the {@code mpdule.xml} as traversable tree
-     *
-     * @return
-     */
-    GPathResult getModuleContent() {
-        new XmlSlurper().parse(getModuleLocation())
-    }
-
-    /** Returns a string suitable for use as the value of {@code Require-Bundle}.
-     *
-     * @return
-     */
-    String getRequireBundle() {
-        List<String> optRes = this.optionalResolution
-        moduleContent.dependencies.module.findAll { module ->
-            !(excludedModuleNames.contains(module.@name.toString()) /*||
-                module.@name=='ceylon.language' && bundleSymbolicName == 'com.redhat.ceylon.model'*/)
-        }.collect { module ->
-            String attr = "${module.@name};bundle-version=${module.@slot}"
-            if(module.@export == 'true') {
-                attr+=";visibility:=reexport"
+    @Override
+    void configureManifestForTask() {
+        archiveTask.manifest.name = bundleSymbolicName
+        archiveTask.manifest {
+            manifestInstructions.each { k,v ->
+                instructionReplace k,v
             }
-            if(module.@optional== 'true' || optRes.contains(module.@name.toString()) ) {
-                attr+=";resolution:=optional"
-            }
-            attr
-        }.join(',')
-
+        }
     }
 
-    private AbstractArchiveTask archiveTask
     private String bundleVersion
-    private List<String> excludedModuleNames = [
-        'java.base','java.compiler','java.logging',
-        'javax.xml','java.instrument',
-        'javax.jaxws','java.desktop',
-        'java.prefs','oracle.jdk.base',
-        'java.jdbc',
-        'javax.script',
-        'java.auth.kerberos',
-        'java.tls',
-        'java.management',
-        'irg.sl4j.simple'
-    ]
-    private List<String> optionalResolution = []
     private Map<String,String> dynamicImports = [:]
 
-    private def moduleLocation
 }

--- a/buildSrc/src/main/groovy/CeylonOsgiArchiveTAskExtension.groovy
+++ b/buildSrc/src/main/groovy/CeylonOsgiArchiveTAskExtension.groovy
@@ -1,0 +1,206 @@
+import groovy.util.slurpersupport.GPathResult
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.util.GradleVersion
+
+/** This extension will be added to each Archive task if
+ * the {@code makeOsgiArchive()} extensions ies executed within the archive
+ * configuration (the latter depends on it being added by the {@code CeylonOsgi}
+ * plugin).
+ */
+class CeylonOsgiArchiveTaskExtension {
+
+    CeylonOsgiArchiveTaskExtension( AbstractArchiveTask task ) {
+        this.archiveTask = task
+    }
+
+    CeylonOsgiArchiveTaskExtension call( Closure cfg ) {
+        def config = cfg.clone()
+        config.delegate = this
+        config()
+        this
+    }
+
+    /** Set to true if javax.lang.model.* needs to be imported
+     *
+     */
+    boolean importJavaxModel = false
+
+    /** Set the symbolic name for this bundle.
+     * Affects {@code Bundle-SymbolicName}
+     */
+    String bundleSymbolicName
+
+    /** Sets the exported bundle version.
+     * Affects {@code Export-Package}
+     */
+    String exportedBundleVersion
+
+    /** Gets the bundle version
+     *
+     * @return If the bundle versions has not been set, return the exported bundle version
+     */
+    String getBundleVersion() {
+        this.bundleVersion ?: exportedBundleVersion
+    }
+
+//    void bundleVersion(final String bv) {
+//        this.bundleVersion = bv
+//    }
+
+    /** Sets an OSGI bundle version.
+     * Affects {@code Bundle-Version}
+     *
+     * @param bv Version string
+     */
+    void setBundleVersion(final String bv) {
+        this.bundleVersion = bv
+    }
+
+    /** Get list of excluded modules
+     *
+     * @return
+     */
+    List<String> getExcludedModuleNames() {
+        this.excludedModuleNames
+    }
+
+    /** Add addition modules to be excluded
+     *
+     * @param names
+     */
+    void excludedModuleNames(String... names) {
+        this.excludedModuleNames.addAll(names as List)
+    }
+
+    /** Override the existing list of excluded module names with a new list.
+     *
+     * @param newModuleNames
+     */
+    void setExcludedModuleNames(final List<String> newModuleNames) {
+        this.excludedModuleNames.clear()
+        this.excludedModuleNames.addAll(newModuleNames)
+    }
+
+    /** If module names matches any of these, then {@code resolution:=optional} will be added
+     * to a {@code Require-Bundle} irrespective of whether the module is marked optioonal or not
+     * @param moduleNames
+     */
+    void forceOptionalResolutionFor(String... moduleNames) {
+        optionalResolution.addAll(moduleNames as List)
+    }
+
+    /** Add packages that needs to be dynamically imported.
+     *
+     * @param importMappings A map in the form of {@code PackagePattern : BundleVersion }
+     */
+    void dynamicImports( Map<String,String> importMappings ) {
+        this.dynamicImports+= importMappings
+    }
+
+    /** Get the list of OSGI manifest instructions as a map
+     *
+     * @return
+     */
+    Map<String,String> getManifestInstructions() {
+        Map<String,String> instructions = [
+            'Bundle-Version' :  getBundleVersion(),
+            'Bundle-SymbolicName' : this.bundleSymbolicName,
+            'Export-Package' : "!about.html, !licenses, !settings.xml, *;version=\"${this.exportedBundleVersion}\"",
+            '-nouses' : 'true',
+            'Gradle-Version' : GradleVersion.current().toString(),
+            'DSTAMP' : TimeStamp.DSTAMP,
+            'NOW' : TimeStamp.NOW,
+            'TODAY' : TimeStamp.TODAY,
+            'TSTAMP' : TimeStamp.TSTAMP
+        ]
+
+        if(dynamicImports.size()) {
+            String packages = dynamicImports.collect { k,v ->
+                k + ';bundle-version=' + v
+            }.join(',')
+            instructions+= [ 'DynamicImport-Package' : packages ]
+        }
+
+        if(importJavaxModel) {
+            instructions+= ['Import-Package' : 'javax.lang.model.*']
+        } else {
+            instructions+= ['-removeheaders' : 'Import-Package' ]
+        }
+
+        String requires = getRequireBundle()
+        if(!requires?.empty) {
+            instructions+= ['Require-Bundle' : requires]
+        }
+        instructions
+    }
+
+    /** Sets the location of the {@code module.xml} file in a lazy-evaluatable manner
+     *
+     * @param location Any location that can be resolve by Gradle's {@code project.file} method.
+     *
+     */
+    void setModuleLocation(def location) {
+        this.moduleLocation = location
+    }
+
+    /** Returns the location of the {@code module.xml} file
+     *
+     * @return
+     */
+    File getModuleLocation() {
+        if(this.moduleLocation == null) {
+            throw new GradleException('moduleLocation cannot be null')
+        }
+        archiveTask.project.file(this.moduleLocation)
+    }
+
+    /** Gets the {@code mpdule.xml} as traversable tree
+     *
+     * @return
+     */
+    GPathResult getModuleContent() {
+        new XmlSlurper().parse(getModuleLocation())
+    }
+
+    /** Returns a string suitable for use as the value of {@code Require-Bundle}.
+     *
+     * @return
+     */
+    String getRequireBundle() {
+        List<String> optRes = this.optionalResolution
+        moduleContent.dependencies.module.findAll { module ->
+            !(excludedModuleNames.contains(module.@name.toString()) /*||
+                module.@name=='ceylon.language' && bundleSymbolicName == 'com.redhat.ceylon.model'*/)
+        }.collect { module ->
+            String attr = "${module.@name};bundle-version=${module.@slot}"
+            if(module.@export == 'true') {
+                attr+=";visibility:=reexport"
+            }
+            if(module.@optional== 'true' || optRes.contains(module.@name.toString()) ) {
+                attr+=";resolution:=optional"
+            }
+            attr
+        }.join(',')
+
+    }
+
+    private AbstractArchiveTask archiveTask
+    private String bundleVersion
+    private List<String> excludedModuleNames = [
+        'java.base','java.compiler','java.logging',
+        'javax.xml','java.instrument',
+        'javax.jaxws','java.desktop',
+        'java.prefs','oracle.jdk.base',
+        'java.jdbc',
+        'javax.script',
+        'java.auth.kerberos',
+        'java.tls',
+        'java.management',
+        'irg.sl4j.simple'
+    ]
+    private List<String> optionalResolution = []
+    private Map<String,String> dynamicImports = [:]
+
+    private def moduleLocation
+}

--- a/buildSrc/src/main/groovy/CeylonOsgiExternalArchiveTaskExtension.groovy
+++ b/buildSrc/src/main/groovy/CeylonOsgiExternalArchiveTaskExtension.groovy
@@ -1,0 +1,101 @@
+import groovy.util.slurpersupport.GPathResult
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.util.GradleVersion
+
+import java.util.jar.Attributes
+
+class CeylonOsgiExternalArchiveTaskExtension  extends AbstractCeylonOsgiArchiveTaskExtension  {
+
+    CeylonOsgiExternalArchiveTaskExtension( AbstractArchiveTask task ) {
+        super(task)
+    }
+
+    CeylonOsgiExternalArchiveTaskExtension call( Closure cfg ) {
+        def config = cfg.clone()
+        config.delegate = this
+        config()
+        this
+    }
+
+    /** If set to {@code true}, new manifest will be created irrespective of whether
+     * JAR contains a valid OSGI manifest.
+     */
+    boolean forceNewOsgiManifest = false
+
+    /** An postifx to identify external dependencies which make up parts of the Ceylon distribution.
+     *
+     */
+    String externalBundleQualifier = 'CEYLON-DEPENDENCIES-v0'
+
+    String suggestNewBundleVersion(final String srcBundleVersion) {
+        switch(srcBundleVersion) {
+            case ~/^[0-9]+\.[0-9]+\.[0-9]+$/ :
+                return "${srcBundleVersion}.${externalBundleQualifier}"
+                break
+            case ~/^[0-9]+\.[0-9]+$/ :
+                return "${srcBundleVersion}.0.${externalBundleQualifier}"
+                break
+            case ~/^[0-9]+$/ :
+                return "${srcBundleVersion}.0.0.${externalBundleQualifier}"
+                break
+            case ~/^[0-9]+\.[0-9]+\.[0-9]+\.[^.]+$/ :
+                return "${srcBundleVersion}.${externalBundleQualifier}"
+                break
+            default:
+                throw new GradleException("External dependency (${bundleSymbolicName}) with a non-supported version")
+        }
+
+    }
+
+    void seedFrom(final File originalJar) {
+        Map<String,String> attrs = [:]
+        originalJar.withInputStream { input ->
+            Attributes mainAttributes = new java.util.jar.JarInputStream(input).manifest.mainAttributes
+            mainAttributes.keySet().each { k ->
+                attrs[k.toString()] = mainAttributes.getValue(k).toString()
+            }
+        }
+        this.seedAttributes.putAll(attrs)
+    }
+
+    @Override
+    void configureManifestForTask() {
+        GPathResult module = moduleContent
+        String bundleVersion
+        String newBundleVersion
+        String bundleSymbolicName = module.@name
+        boolean hasOsgi = false
+
+
+        if(!seedAttributes.empty) {
+            hasOsgi = seedAttributes['Bundle-Version']?.size()
+
+            bundleVersion = seedAttributes['Bundle-Version'] ?: module.@slot
+            newBundleVersion = suggestNewBundleVersion(bundleVersion)
+        }
+
+
+        if(!hasOsgi || forceNewOsgiManifest) {
+            Map instructions = getManifestInstructions(
+                newBundleVersion,
+                bundleSymbolicName,
+                bundleVersion ?: module.@slot
+            )
+            Map <String,String> merged = [:]
+            merged.putAll(seedAttributes)
+            merged.putAll(instructions)
+            merged.remove('Import-Package')
+
+            archiveTask.manifest.attributes merged
+        } else {
+            seedAttributes['Bundle-Version'] = newBundleVersion
+            archiveTask.manifest.attributes seedAttributes
+            archiveTask.manifest.instructionReplace 'Gradle-Version', GradleVersion.current().toString()
+        }
+
+    }
+
+    private final Map<String,String> seedAttributes = [:]
+
+}

--- a/buildSrc/src/main/groovy/CeylonOsgiExternalArchiveTaskExtension.groovy
+++ b/buildSrc/src/main/groovy/CeylonOsgiExternalArchiveTaskExtension.groovy
@@ -70,7 +70,6 @@ class CeylonOsgiExternalArchiveTaskExtension  extends AbstractCeylonOsgiArchiveT
 
         if(!seedAttributes.empty) {
             hasOsgi = seedAttributes['Bundle-Version']?.size()
-
             bundleVersion = seedAttributes['Bundle-Version'] ?: module.@slot
             newBundleVersion = suggestNewBundleVersion(bundleVersion)
         }

--- a/buildSrc/src/main/groovy/TimeStamp.groovy
+++ b/buildSrc/src/main/groovy/TimeStamp.groovy
@@ -3,9 +3,25 @@ import java.text.SimpleDateFormat
 
 @CompileStatic
 class TimeStamp {
+    static final BUILD_START = new Date()
     static final String BUILD = {
-        Date today = new Date ()
         SimpleDateFormat df = new SimpleDateFormat ("'v'yyyyMMdd-HHmm")
-        return df.format (today)
+        return df.format (BUILD_START)
+    }.call()
+    static final String DSTAMP = {
+        SimpleDateFormat df = new SimpleDateFormat ("yyyyMMdd")
+        return df.format (BUILD_START)
+    }.call()
+    static final String NOW = {
+        SimpleDateFormat df = new SimpleDateFormat ("yyyyMMddHHmm")
+        return df.format (BUILD_START)
+    }.call()
+    static final String TODAY = {
+        SimpleDateFormat df = new SimpleDateFormat ("MMM dd yyyy")
+        return df.format (BUILD_START)
+    }.call()
+    static final String TSTAMP = {
+        SimpleDateFormat df = new SimpleDateFormat ("HHmm")
+        return df.format (BUILD_START)
     }.call()
 }

--- a/common/common.gradle
+++ b/common/common.gradle
@@ -1,7 +1,6 @@
 ext {
     ceylonModuleName = 'common'
     ceylonTestDisabled = true
-
 }
 
 apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"

--- a/compiler-java/compilerjava.gradle
+++ b/compiler-java/compilerjava.gradle
@@ -8,6 +8,7 @@ ext {
 
 apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"
 requiresCBP 'module.ceylon.bootstrap.version'
+requiresCBP 'ceylon.bootstrap.dir'
 
 dependencies {
     compile project(':common')
@@ -125,6 +126,10 @@ jar {
     exclude "com/redhat/ceylon/ant/**"
     exclude "com/redhat/ceylon/common/**"
     exclude "com/redhat/ceylon/launcher/**"
+
+    ceylon {
+        importJavaxModel true
+    }
 }
 
 
@@ -162,27 +167,44 @@ task bootstrapJar( type : Jar ) {
     }
 }
 
+task bootstrapModuleXml( type : CeylonBuildModuleXml ) {
+    description "Create module.xml for the bootstrap JAR"
+    sourceModule {
+        new File(project.file("${project(':runtime').projectDir}/dist/repo/" +
+            cbp."ceylon.bootstrap.dir").parentFile, '/_version_/module.xml')
+    }
+    destinationDir = {"${moduleXml.destinationDir}/bootstrap"}
+}
 
 task bootstrapModule( type : Jar ) {
+    group 'Build'
+    description 'Create bootstrap module'
+    setAsOsgiArchive()
+    dependsOn classes, processResources, bootstrapModuleXml
+    destinationDir = jar.destinationDir
+
     ext {
         bmSymbolicName = 'com.redhat.ceylon.bootstrap'
         bmVersionName = cbp."module.ceylon.bootstrap.version"
     }
-    manifest {
-        attributes 'Bundle-SymbolicName': bmSymbolicName,
-            'Bundle-Version': bmVersionName + ".${TimeStamp.BUILD}"
+
+    ceylon {
+        importJavaxModel  false
+        bundleSymbolicName bmSymbolicName
+        exportedBundleVersion bmVersionName+".${TimeStamp.BUILD}"
+        moduleLocation {bootstrapModuleXml.destinationFile}
+        forceOptionalResolutionFor 'ceylon.runtime'
     }
-    group 'Build'
-    description 'Create bootstrap module'
-    dependsOn classes, processResources
-    destinationDir = jar.destinationDir
-//        ceylon.bootstrap.dir=ceylon/bootstrap/${module.ceylon.bootstrap.version}
-//    ceylon.bootstrap.jar=${ceylon.bootstrap.dir}/ceylon.bootstrap-${module.ceylon.bootstrap.version}.jar
+
     archiveName = "ceylon.bootstrap-${bmVersionName}.jar"
 
     from sourceSets.main.output.classesDir, {
         include "com/redhat/ceylon/launcher/**"
         exclude "com/redhat/ceylon/launcher/Start.class"
+    }
+
+    from bootstrapModuleXml, {
+        into "META-INF/jbossmodules/" + cbp."ceylon.bootstrap.dir"
     }
 
 }
@@ -221,21 +243,4 @@ publishInternal {
     dependsOn publishBootstrapModule
 }
 
-
-//"""
-//    <target name="compiler.jar" depends="compiler.classes">
-//        <mkdir dir="${build.dist.repo}/${ceylon.compiler.dir}" />
-//        <mkdir dir="${build.bin}" />
-
-//        <jar destfile="${build.dist.repo}/${ceylon.compiler.jar}">
-//        <jar destfile="${build.dist.repo}/${ceylon.bootstrap.jar}">
-
-//ceylon.bootstrap.dir=ceylon/bootstrap/${module.ceylon.bootstrap.version}
-//ceylon.bootstrap.jar=${ceylon.bootstrap.dir}/ceylon.bootstrap-${module.ceylon.bootstrap.version}.jar
-//ceylon.bootstrap.lib=${ceylon.repo.dir}/${ceylon.bootstrap.jar}
-
-//ceylon.compiler.dir=com/redhat/ceylon/compiler/java/${module.com.redhat.ceylon.compiler.version}
-//ceylon.compiler.jar=${ceylon.compiler.dir}/com.redhat.ceylon.compiler.java-${module.com.redhat.ceylon.compiler.version}.jar
-//ceylon.compiler.lib=${ceylon.repo.dir}/${ceylon.compiler.jar}
-
-//"""
+// TODO: Do something different for Jigsaw

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -86,14 +86,46 @@ task copySupportFiles( type : Copy) {
     }
 }
 
+task generateBuildId {
+
+    group "Build"
+    description "Generates teh BUILDID file"
+
+    ext {
+        idFile = file("${distDir}/BUILDID")
+
+        getRevision = { OutputStream os ->
+            project.exec {
+                standardOutput = os
+                commandLine 'git','rev-parse', '--short', 'HEAD'
+            }
+            os.toString()
+        }
+    }
+
+
+    doFirst {
+        idFile.withOutputStream { os ->
+            getRevision(os)
+        }
+    }
+
+    outputs.upToDateWhen {
+        idFile.exists() && getRevision( new ByteArrayOutputStream() ) == idFile.text
+    }
+
+    outputs.file idFile
+    enabled = file("${rootProject.projectDir}/.git").exists()
+}
+
+
 task publishInternal {
     group 'Distribution'
     description "Lifecycle task to cooridnate all internal publish tasks"
     dependsOn setupRepo, installCompiler, installJS
     dependsOn copyCompilerBinaries, copySupportFiles
     dependsOn installRuntime
-    // addModuleDescriptors
-    // generateBuildId
+    dependsOn generateBuildId
 }
 
 

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -124,3 +124,4 @@ task cleanRepo ( type : Delete ) {
     delete samplesDir
     delete repoDir
 }
+

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -92,14 +92,26 @@ task generateBuildId {
     description "Generates teh BUILDID file"
 
     ext {
+        hasGitRepository = file("${rootProject.projectDir}/.git").exists()
+        providedBuildId = project.properties.buildid ?: System.getProperty('buildid')
         idFile = file("${distDir}/BUILDID")
 
-        getRevision = { OutputStream os ->
-            project.exec {
-                standardOutput = os
-                commandLine 'git','rev-parse', '--short', 'HEAD'
+        getRevision = { OutputStream os,boolean silent=false ->
+            if (hasGitRepository) {
+                project.exec {
+                    standardOutput = os
+                    commandLine 'git','rev-parse', '--short', 'HEAD'
+                }
+                os.toString()
+            } else if (providedBuildId) {
+                os << providedBuildId
+                providedBuildId
+            } else {
+                if(buildid == null && !silent) {
+                    logger.error "Git executable not found -Pbuildid / -Dbuilid was not specified."
+                }
+                null
             }
-            os.toString()
         }
     }
 
@@ -111,11 +123,11 @@ task generateBuildId {
     }
 
     outputs.upToDateWhen {
-        idFile.exists() && getRevision( new ByteArrayOutputStream() ) == idFile.text
+        idFile.exists() && getRevision( new ByteArrayOutputStream(),true ) == idFile.text
     }
 
     outputs.file idFile
-    enabled = file("${rootProject.projectDir}/.git").exists()
+    enabled = hasGitRepository || providedBuildId != null
 }
 
 

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -96,7 +96,7 @@ task generateBuildId {
         providedBuildId = project.properties.buildid ?: System.getProperty('buildid')
         idFile = file("${distDir}/BUILDID")
 
-        getRevision = { OutputStream os,boolean silent=false ->
+        getRevision = { OutputStream os->
             if (hasGitRepository) {
                 project.exec {
                     standardOutput = os
@@ -106,11 +106,6 @@ task generateBuildId {
             } else if (providedBuildId) {
                 os << providedBuildId
                 providedBuildId
-            } else {
-                if(buildid == null && !silent) {
-                    logger.error "Git executable not found -Pbuildid / -Dbuilid was not specified."
-                }
-                null
             }
         }
     }
@@ -123,11 +118,15 @@ task generateBuildId {
     }
 
     outputs.upToDateWhen {
-        idFile.exists() && getRevision( new ByteArrayOutputStream(),true ) == idFile.text
+        idFile.exists() && getRevision( new ByteArrayOutputStream() ) == idFile.text
     }
 
     outputs.file idFile
     enabled = hasGitRepository || providedBuildId != null
+
+    if(!ext.hasGitRepository && ext.providedBuildId == null) {
+        logger.error "Git repository not found and -Pbuildid / -Dbuilid was not specified."
+    }
 }
 
 

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -261,3 +261,23 @@ Gradle lifecycle tasks to appropriate ones in the Ant build.
 | `tool-provider | Disabled (requires updates to Gradle script)
 | `typechecker` | Disabled (requires updates to Gradle script)
 |===
+
+== Other items
+
+[quote,https://github.com/ceylon/ceylon/pull/6378#issuecomment-233606475]
+----
+Another thing is that the Ant build creates a BUILDID file in the distribution folder that contains the (short) Git commit id of the current HEAD of the Git repository that is being used to build things. The same ID is also replaced in the common/src/com/redhat/ceylon/common/Versions.java file.
+Look at the defcurrentcommit task in dist/build.xml for how we do that. (We run git rev-parse --short HEAD)
+But it should also be possible to define the buildid on the command line when executing the gradlew build command in case we're trying to build plain sources (not from a Git repository). In case of Ant we do this by passing -Dbuildid=XXXX on the command line.
+(We haven't done this for ant, but an error message if no Git repository was found and also no -Dbuildid was passed would be great)
+
+Also missing from the root distribution folder are: contrib, LICENSE-ASL, LICENSE-GPL-CP, NOTICE, README.md, samples and templates. These can simply be copied from dist.
+
+
+
+Hah, you actually improved something: in our distribution the bin/ceylon-compile-js.plugin file is missing!
+
+From my previous comment I failed to mention the dist/bin folder. It's contents should also be copied to the distribution's bin folder. (We're missing bin/ceylon-format.plugin)
+
+----
+

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -23,7 +23,8 @@ Ant & Gradle builds.
              copy-samples, copy-templates, copy-contrib, copy-licenses, <!-- 4 -->
              copy-jvm-compiler-libraries, <!-- 5 -->
               install-runtime, <!-- 6 -->
-             add-module-descriptors, generate-buildid"
+             add-module-descriptors, <!-- 7 -->
+             generate-buildid"
     description="Generates all binaries and copies them to the distribution folder">
 </target>
 ----
@@ -34,6 +35,8 @@ Ant & Gradle builds.
 <4> `copy-licenses`, `copy-samples`, `copy-templates` & `copy-contrib` handled by `:dist:copySupportFiles`
 <5> `copy-jvm-compiler-libraries` handled by `:compiler-java:publishInternal`.
 <6> `install-runtime` handled by `:distinstallRuntime`.
+<7> `add-module-descriptors` is not handle in two ways. For Ceylon-specific artifacts this is part of the build
+  in each subproject. For external artifacts this is indirectly covered by `:runtime:setupRepo`.
 
 In addition the `copy-dist-bin` Ant task is handled by
 
@@ -61,7 +64,8 @@ Needed a special `sourceSet` layout.
 As all of the four Ant `javac` tasks ended up in a single JAR and used the same compilation options,
  I think putting them into a single compilation task was the way to go.
 
-In order to rename `_version_` when copying XML files, the use of `eachFile` was necessary.
+In an relaier restructuring effort there was an issue with stray `_version_` folders be left around.
+This problem has now been eliminated due to the new way that OSIGi headers are being added.
 
 .TODO
 * What about those `pom.xml` files that are dotted over the place?
@@ -82,10 +86,6 @@ In order to rename `_version_` when copying XML files, the use of `eachFile` was
 === Cmr-aether
 
 Standard Ceylon Java project.
-
-.TODO
-* Publishing
-* Source Zip
 
 === Cmr-webdav
 
@@ -150,7 +150,6 @@ and that seems to be forcing Ant to build into Gradle's `buildDir`.
 There is an unfortunate interdependency with `compiler-java`.
 
 .TODO
-* Publishing
 * Fix it from going through the Ant build to building everything as part of Gradle direct.
 * Start using `generate-source.gradle` to generate source.
 * Set `generateModuleInfo` according to `jigsaw`.

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -8,6 +8,7 @@ Ant & Gradle builds.
 * ide-quick
 * bundle-proxy
 * Tests are disabled globally.
+* Jigsaw support via `-Pjigsaw=1`
 
 == Subprojects
 
@@ -218,6 +219,29 @@ It also provides a `requiresCBP` method that will fail the build if a specific p
 A local plugin that mimics a number of conventions of the builtin Gradle `antlr` plugin, but is stripped down in
 functionality and covers just enough to work within the Ceylon build environment.
 
+=== CeylonBuildOsgiPLugin
+
+Activates OSGI support.
+
+* Adds a `ceylon` extension to the `jar` task.
+* Adds a method `setAsOsgiArchive()` to every `Jar` task, which can be called to invoke OSGI support on the task,
+  This means that the `ceylon` extension will become available to be used in th task configuration and that the
+  manifest will be converted an OSGI manifest.
+* OSGI-enabled `Jar` tasks will automatically configure the OSGI metadata based upon information configured in
+  the `ceylon` block.
+* Also adds a `moduleXml` task which is of type `CeylonBuildModuleXml`.
+
+=== CeylonBuildXml
+
+It's primary purpose is to copy a `module.xml` file into the build directory and perform substitutionts. Such
+a file can then be added to a JAR and/or be copied to the distribution area.
+
+=== CeylonOsgiArchiveTaskExtension
+
+Adds a number of configurations which can be used to configure the necessary OSGI metadata in way that is very
+specific to the Ceylon build. The file has been well documented and can be used as reference.
+
+===
 == Custom build in gradle folder
 
 A number of common functionality not suitable for buildSrc have been added as buildscript in the `gradle` folder

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -64,8 +64,9 @@ Needed a special `sourceSet` layout.
 As all of the four Ant `javac` tasks ended up in a single JAR and used the same compilation options,
  I think putting them into a single compilation task was the way to go.
 
-In an relaier restructuring effort there was an issue with stray `_version_` folders be left around.
-This problem has now been eliminated due to the new way that OSIGi headers are being added.
+In an earlier https://github.com/ceylon/ceylon/pull/6378[#6378] restructuring effort there was an
+issue with stray `_version_` folders be left around.
+This problem has now been eliminated due to the new way that <<OSGIHeader,OSGi headers>> are being added.
 
 .TODO
 * What about those `pom.xml` files that are dotted over the place?
@@ -126,7 +127,7 @@ Finally `compileJava` has to depend on `tree`, whereafter all of the tasks suppl
 starts to work.
 
 .TODO
-* The Ant `antlr.tree` deleted tokens at the end. SHould we still do that?
+* The Ant `antlr.tree` deleted tokens at the end. Should we still do that?
 
 === Compiler-java
 
@@ -285,6 +286,87 @@ Gradle lifecycle tasks to appropriate ones in the Ant build.
 | `typechecker` | Disabled (requires updates to Gradle script)
 |===
 
+[[OSGIheaders]]
+== Generating OSGI headers
+
+In order to deal with OSGI headers, the  GRadle `osgi` plugin is applied and a custom task extension is
+added to the 'jar` task. This is activated by applying the `CeylonBuildOsgiPlugin`. Other Jar tasks can have this
+fucntionality actived by adding `setAsOsgiExternalArchive()` (for external artifcats) or
+`setAsOsgiArchive()` (for  Ceylon-specific artifacts) to the configuration block. Both cases enable a new
+extension block called `ceylon` but the configuration options are slightly different:
+
+[cols="4*"]
+|===
+| Option
+| `setAsOsgiExternalArchive`
+| `setAsOsgiArchive`
+| Usage
+
+| `bundleSymbolicName`
+| -
+| *Y*
+| Set the symbolic name for this bundle. Affects `Bundle-SymbolicName`.
+
+| `bundleVersion`
+| -
+| *Y*
+| Sets an OSGI bundle version. If not set will use the value from `exportedBundleVersion`.
+  Affects `Bundle-Version`.
+
+| `dynamicImports`
+| -
+| *Y*
+| Provide one or more modules that will be be dynamically imported. This is done in key-value format i.e.
+  `PackagePattern : BundleVersion`.
+
+| `excludeModuleNames`
+| *Y*
+| *Y*
+| Provide one or more modules than are excluded above and beyond the standard list. Using this with the
+  assignment operator will ovveride all existing excluded modules.
+
+| `exportedBundleVersion`
+| -
+| *Y*
+| Sets the exported bundle version. Affects `Export-Package`.
+
+| `externalBundleQualifier`
+| *Y*
+| -
+| A postfix to identify external dependencies which make up parts of the Ceylon distribution.
+  Defaults to 'CEYLON-DEPENDENCIES-v0'.
+
+| `forceNewOsgiManifest`
+| *Y*
+| -
+| If set to `true`, a new OSGI manifest will be created irrespective of whether the JAR contains a
+  valid OSGI manifest. Defaults to `false.
+
+| `forceOptionalResolutionFor`
+| *Y*
+| *Y*
+| Provide one or more module names for which `resolution:=optional` will be added to
+   `Require-Bundle` attribute irrespective of whther the module is marked `optional` or not
+
+| `importJavaxModel`
+| *Y*
+| *Y*
+| Set to `true` if ``javax.lang.model.*` needs to be imported. Defaults to `false`.
+
+| `moduleLocation`
+| *Y*
+| *Y*
+| Sets the location of the `module.xml` file in a lazy-evaluatable manner as long as Gradle's
+`project.file` method can resolve it.
+
+| `seedFrom`
+| *Y*
+| -
+| Path to a JAR where to read the original manifest from.
+
+|===
+
+
 == Other items
 
 [quote,https://github.com/ceylon/ceylon/pull/6378#issuecomment-233606475]
@@ -296,9 +378,7 @@ But it should also be possible to define the buildid on the command line when ex
 
 Also missing from the root distribution folder are: contrib, LICENSE-ASL, LICENSE-GPL-CP, NOTICE, README.md, samples and templates. These can simply be copied from dist.
 
-
-
-Hah, you actually improved something: in our distribution the bin/ceylon-compile-js.plugin file is missing!
+Hah, you actually improved something: in our distribution the bin/ceylon-compile-js.pluin file is missing!
 
 From my previous comment I failed to mention the dist/bin folder. It's contents should also be copied to the distribution's bin folder. (We're missing bin/ceylon-format.plugin)
 

--- a/gradle/java-for-modules.gradle
+++ b/gradle/java-for-modules.gradle
@@ -40,21 +40,12 @@ ext {
     archivePublishDir = "${repoDir}/" +  cbp."ceylon.${ceylonPublishModuleName}.dir"
 }
 
-//com.read.ceylon.compiler-1.2.3,jar
-//archiveName = "${bundleSymbolicName}-${bundleVersionName}.jar"
-//ceylon.compiler.jar=${ceylon.compiler.dir}/com.redhat.ceylon.compiler.java-${module.com.redhat.ceylon.compiler.version}.jar
-//ceylon.compiler.dir=com/redhat/ceylon/compiler/java/${module.com.redhat.ceylon.compiler.version}
-
 if(!ext.properties.containsKey('ceylonSourceLayout')) {
         ext.ceylonSourceLayout = true
 }
 
 apply plugin: 'java'
-
-ext {
-    // By default projects use a flat source hierarchy
-    defaultSources = false
-}
+apply plugin : CeylonBuildOsgiPlugin
 
 dependencies {
     testCompile 'junit:junit:4.11'
@@ -106,12 +97,39 @@ if (ext.ceylonSourceLayout) {
 }
 
 
-jar {
-    manifest {
-        attributes 'Bundle-SymbolicName': bundleSymbolicName,
-            'Bundle-Version': bundleVersionName+".${TimeStamp.BUILD}"
+moduleXml {
+    sourceModule {
+        new File(project.file("${project(':runtime').projectDir}/dist/repo/" +
+            cbp."ceylon.${ceylonPublishModuleName}.dir").parentFile, '/_version_/module.xml')
     }
+}
+
+//jar {
+//    manifest {
+//        attributes 'Bundle-SymbolicName': bundleSymbolicName,
+//            'Bundle-Version': bundleVersionName+".${TimeStamp.BUILD}"
+//    }
+//    archiveName = "${bundleSymbolicName}-${bundleVersionName}.jar"
+//}
+
+
+
+jar {
+    dependsOn moduleXml
+
+    ceylon {
+        importJavaxModel  false
+        bundleSymbolicName project.ext.bundleSymbolicName
+        exportedBundleVersion project.ext.bundleVersionName+".${TimeStamp.BUILD}"
+        moduleLocation {moduleXml.destinationFile}
+    }
+
+    from moduleXml, {
+        into "META-INF/jbossmodules/" + cbp."ceylon.${ceylonPublishModuleName}.dir"
+    }
+
     archiveName = "${bundleSymbolicName}-${bundleVersionName}.jar"
+
 }
 
 task sourceZip( type : Zip ) {
@@ -131,7 +149,6 @@ task sha1 ( type : Checksum ) {
     dependsOn jar, sourceZip
 }
 
-
 task publishJar( type : Copy ) {
     group 'Distribution'
     description 'Copies binary artifacts to distribution area'
@@ -141,6 +158,7 @@ task publishJar( type : Copy ) {
     }
 
     from jar
+    from moduleXml
     into archivePublishDir
 }
 

--- a/model/model.gradle
+++ b/model/model.gradle
@@ -9,6 +9,15 @@ dependencies {
     compile project(':langtools-classfile')
 }
 
+jar {
+    ceylon {
+        excludedModuleNames 'ceylon.language'
+        importJavaxModel true
+        dynamicImports 'ceylon.language.*' : version,
+            'com.redhat.ceylon.compiler.java.*' : version
+    }
+}
+
 ['common','langtools-classfile'].each {
     publishInternal.dependsOn ":${it}:publishInternal"
 }

--- a/runtime/runtime.gradle
+++ b/runtime/runtime.gradle
@@ -9,6 +9,10 @@ ext {
 apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"
 
 
+ext {
+    externalDepsDestinationDir = "${buildDir}/ceylon-runtime"
+}
+
 dependencies {
     compile project(':common')
     compile project(':cli')
@@ -17,7 +21,6 @@ dependencies {
     compile project(':tool-provider')
     compile project( path : ':language', configuration : 'antOutput')
 }
-
 
 sourceSets {
     main {
@@ -46,48 +49,86 @@ task pluginFiles( type : Copy ) {
     filter ReplaceTokens, tokens : [ 'ceylon-version' : version ]
 }
 
+task addModuleDescriptorsForExternalDependencies {
+    group "Build"
+    description "Lifecycle task for handling external dependencies"
+}
+
+task fakeClasseDirForExternalDependencies  {
+    ext {
+        outputDir = file("${externalDepsDestinationDir}/classes")
+    }
+    outputs.dir outputDir
+    doFirst {
+        mkdir outputDir
+    }
+}
+
+// Add tasks for each of the external JARs
+(fileTree('dist/repo') {
+    include '**/*.jar'
+    exclude "**/ceylon/**" // <-- we do this as we have moved ceylon modules to their own subprojects.
+}).files.each { jarFile ->
+    String taskNamePostfix = jarFile.name[0..-5]
+    String relativePath = CeylonBuildUtil.relativeTo(jarFile.parentFile.absoluteFile,file('dist/repo'))
+
+    Task moduleTask = tasks.create( "addModuleXml_${taskNamePostfix}", CeylonBuildModuleXml) {
+        group "Build"
+        description "Prepare module.xml for ${taskNamePostfix}"
+        sourceModule new File(jarFile.parentFile,'module.xml')
+        destinationDir "${externalDepsDestinationDir}/${relativePath}"
+    }
+
+    Task osgiJar = tasks.create( "addOsgiManifest_${taskNamePostfix}", Jar ) {
+        group "Build"
+        description "Add OSGI data to manifest for ${taskNamePostfix}"
+        archiveName jarFile.name
+        destinationDir  file("${externalDepsDestinationDir}/${relativePath}")
+        dependsOn moduleTask
+        dependsOn fakeClasseDirForExternalDependencies
+        setAsOsgiExternalArchive()
+
+        from zipTree(jarFile), {
+            exclude 'META-INF/MANIFEST.MF'
+        }
+
+        manifest {
+            classesDir fakeClasseDirForExternalDependencies.outputDir
+        }
+
+        ceylon {
+            seedFrom jarFile
+            moduleLocation {moduleTask.destinationFile}
+            forceNewOsgiManifest relativePath.matches(~/.+[\\\/](logmanager|slf4j)[\\\/].+/)
+        }
+
+        from moduleTask, {
+            into "META-INF/jbossmodules/${relativePath}"
+        }
+
+        doFirst { mkdir manifest.classesDir }
+    }
+
+    addModuleDescriptorsForExternalDependencies.dependsOn osgiJar, moduleTask
+}
+
 assemble {
-    dependsOn pluginFiles
+    dependsOn pluginFiles, addModuleDescriptorsForExternalDependencies
+}
+
+task setupRepo( type : Copy ) {
+    group "Setup"
+    description "Setup the basic structure of the dist folder by copying the template folder"
+    dependsOn addModuleDescriptorsForExternalDependencies
+    into repoDir
+    from externalDepsDestinationDir
+}
+
+['common','cmr','language','tool-provider','java-main'].each {
+    publishInternal.dependsOn ":${it}:publishInternal"
 }
 
 // TODO: Can be removed if language build is pure Gradle
 compileJava.dependsOn ':language:assemble'
 
 
-task setupRepo( type : Copy ) {
-    group "Setup"
-    description "Setup the basic structure of the dist folder by copying the template folder"
-    into repoDir
-    from 'dist/repo', {
-        include "**/*.xml"
-        exclude "**/ceylon/**" // <-- we do this as we have moved ceylon modules to their own subprojects.
-        filter ReplaceTokens, tokens : [ 'ceylon-version' : version ]
-    }
-    from 'dist/repo', {
-        include '**/*.jar'
-        exclude "**/ceylon/**" // <-- we do this as we have moved ceylon modules to their own subprojects.
-    }
-    eachFile { fcd ->
-        fcd.path = fcd.path.replace('_version_',version)
-    }
-
-    doFirst {
-        logger.info "TODO: Copying hardcoded JARs might be better dealt with using Gradle's dependency management"
-    }
-
-    doLast {
-        // Necessary due to unexpected behaviour in eachFile
-        // See https://discuss.gradle.org/t/modifying-parent-paths-in-a-copy-task-creates-unnecessary-remnants/18567
-        fileTree(destinationDir) {
-            include '**/_version_'
-        }.visit {
-            if(it.isDirectory() && it.name == '_version_') {
-                delete it.file
-            }
-        }
-    }
-}
-
-['common','cmr','language','tool-provider','java-main'].each {
-    publishInternal.dependsOn ":${it}:publishInternal"
-}

--- a/runtime/runtime.gradle
+++ b/runtime/runtime.gradle
@@ -60,10 +60,12 @@ task setupRepo( type : Copy ) {
     into repoDir
     from 'dist/repo', {
         include "**/*.xml"
+        exclude "**/ceylon/**" // <-- we do this as we have moved ceylon modules to their own subprojects.
         filter ReplaceTokens, tokens : [ 'ceylon-version' : version ]
     }
     from 'dist/repo', {
         include '**/*.jar'
+        exclude "**/ceylon/**" // <-- we do this as we have moved ceylon modules to their own subprojects.
     }
     eachFile { fcd ->
         fcd.path = fcd.path.replace('_version_',version)
@@ -89,55 +91,3 @@ task setupRepo( type : Copy ) {
 ['common','cmr','language','tool-provider','java-main'].each {
     publishInternal.dependsOn ":${it}:publishInternal"
 }
-
-//
-//"""
-//    <target name="runtime.classes">
-//        <mkdir dir="${build.classes}"/>
-
-//        <javac debug="true"
-//               encoding="UTF-8"
-//               srcdir="${runtime-spi.src}"
-//               destdir="${build.classes}"
-//               classpathref="compiler.classpath"
-//               target="${compile.java.target}"
-//               source="${compile.java.source}"
-//               bootclasspath="${compile.java.bootclasspath}"
-//               includeantruntime="false"/>
-
-//        <javac debug="true"
-//               encoding="UTF-8"
-//               srcdir="${runtime-api.src}"
-//               destdir="${build.classes}"
-//               classpathref="compiler.classpath"
-//               target="${compile.java.target}"
-//               source="${compile.java.source}"
-//               bootclasspath="${compile.java.bootclasspath}"
-//               includeantruntime="false"/>
-
-//        <javac debug="true"
-//               encoding="UTF-8"
-//               srcdir="${runtime-impl.src}"
-//               destdir="${build.classes}"
-//               classpathref="compiler.classpath"
-//               target="${compile.java.target}"
-//               source="${compile.java.source}"
-//               bootclasspath="${compile.java.bootclasspath}"
-//               includeantruntime="false"/>
-
-//        <javac debug="true"
-//               encoding="UTF-8"
-//               srcdir="${runtime-bootstrap.src}"
-//               destdir="${build.classes}"
-//               classpathref="compiler.classpath"
-//               target="${compile.java.target}"
-//               source="${compile.java.source}"
-//               bootclasspath="${compile.java.bootclasspath}"
-//               includeantruntime="false"/
-
-//        <!-- Include META-INF -->
-//        <copy todir="${build.classes}">
-//            <fileset dir="${runtime-bootstrap.src}" excludes="**/*.java"/>
-//        </copy>
-//    </target>
-//

--- a/runtime/runtime.gradle
+++ b/runtime/runtime.gradle
@@ -60,17 +60,29 @@ task setupRepo( type : Copy ) {
     into repoDir
     from 'dist/repo', {
         include "**/*.xml"
-        eachFile { fcd ->
-            fcd.path = fcd.path.replace('_version_',version)
-            fcd.filter ReplaceTokens, tokens : [ 'ceylon-version' : version ]
-        }
+        filter ReplaceTokens, tokens : [ 'ceylon-version' : version ]
     }
     from 'dist/repo', {
         include '**/*.jar'
     }
+    eachFile { fcd ->
+        fcd.path = fcd.path.replace('_version_',version)
+    }
 
     doFirst {
         logger.info "TODO: Copying hardcoded JARs might be better dealt with using Gradle's dependency management"
+    }
+
+    doLast {
+        // Necessary due to unexpected behaviour in eachFile
+        // See https://discuss.gradle.org/t/modifying-parent-paths-in-a-copy-task-creates-unnecessary-remnants/18567
+        fileTree(destinationDir) {
+            include '**/_version_'
+        }.visit {
+            if(it.isDirectory() && it.name == '_version_') {
+                delete it.file
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This builds upon #6378.

_Main features:_
- OSGI attributes & `module.xml`
  - For Ceylon-specific modules, the attributes/headers are added at the time the JAR is built. THe `module.xml` files are transformed at the same time (They still remain in `runtime` as the source folder for the time being in order to be comaptible with the Ant build). A `ceylon` extension block is added to the `jar` task to customise as need be.
  - For external-dependencies, the tranformation is done in the `runtime` project as part of the `setupRepo`. One task per JAR and one task per `module.xml` are auto-generated in the `runtime` subproject.
- `BUILDID` file is now generated.
- Addressed issues mentioned by @quintesse in #6378.
  - Addition of `LICENSE` etc. files to root of distribution folder
  - Addition of `ceylon-format.plugin` to `bin` subfodler of distribution folder

_Outstanding:_
- `proxy-bundle`, `ide`, `sdk`
- A number of TODOs are still listed in `gradle-migration.adoc`.

_Known issues:_

After a `.gradlew` clean from the top the first build will fail iin `language`. A subsequent build will pass. This has something to do with the way the ANT task jat is being made available on the classpath.
- `gradle-migration.adoc` still mentions a
