### PR TITLE
Restructuring Gradle Build #4 - Fixing 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ task dist {
 }
 
 task clean ( type : Delete ) {
-    delete buildDir
+    delete buildPrefix
 }
 
 task 'clean-all' {

--- a/buildSrc/src/main/groovy/CeylonBuildIdGenerator.groovy
+++ b/buildSrc/src/main/groovy/CeylonBuildIdGenerator.groovy
@@ -5,13 +5,14 @@ import org.gradle.api.tasks.TaskAction
 class CeylonBuildIdGenerator extends DefaultTask {
 
     CeylonBuildIdGenerator() {
-        buildInfo = project.extensions.getByType(CeylonBuildInfoPlugin.BuildInfo)
-        enabled = buildInfo.hasGitRepository || buildInfo.providedBuildId != null
+        this.buildInfo = project.extensions.getByType(CeylonBuildInfoPlugin.BuildInfo)
+        enabled = this.buildInfo.hasGitRepository || this.buildInfo.providedBuildId != null
+
 
         outputs.upToDateWhen {
             if(this.outputFile !=null) {
                 File out = getOutputFile()
-                out.exists() && buildInfo.revisionInfo == out.text
+                out.exists() && project.extensions.getByType(CeylonBuildInfoPlugin.BuildInfo).revisionInfo == out.text
             } else {
                 false
             }

--- a/buildSrc/src/main/groovy/CeylonBuildIdGenerator.groovy
+++ b/buildSrc/src/main/groovy/CeylonBuildIdGenerator.groovy
@@ -1,0 +1,49 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+class CeylonBuildIdGenerator extends DefaultTask {
+
+    CeylonBuildIdGenerator() {
+        buildInfo = project.extensions.getByType(CeylonBuildInfoPlugin.BuildInfo)
+        enabled = buildInfo.hasGitRepository || buildInfo.providedBuildId != null
+
+        outputs.upToDateWhen {
+            if(this.outputFile !=null) {
+                File out = getOutputFile()
+                out.exists() && buildInfo.revisionInfo == out.text
+            } else {
+                false
+            }
+        }
+    }
+
+    /** Returns the output file
+     *
+     * @return
+     */
+    @OutputFile
+    File getOutputFile() {
+        project.file(this.outputFile)
+    }
+
+    /** Sets the output file
+     *
+     * @param f Anything that be converted to {@code project.file}
+     */
+    void setOutputFile(Object f) {
+        this.outputFile = f
+    }
+
+    @TaskAction
+    void exec() {
+        String buildid = buildInfo.revisionInfo
+
+        if(buildid) {
+            getOutputFile().text = buildid
+        }
+    }
+
+    private final CeylonBuildInfoPlugin.BuildInfo buildInfo
+    private def outputFile
+}

--- a/buildSrc/src/main/groovy/CeylonBuildInfoPlugin.groovy
+++ b/buildSrc/src/main/groovy/CeylonBuildInfoPlugin.groovy
@@ -1,0 +1,40 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class CeylonBuildInfoPlugin implements Plugin<Project> {
+
+    static final String EXTENSION_NAME = 'ceylonBuildInfo'
+    void apply(Project project) {
+        project.extensions.create( EXTENSION_NAME, CeylonBuildInfoPlugin.BuildInfo,project )
+    }
+
+    static class BuildInfo {
+        final boolean hasGitRepository
+        final String providedBuildId
+        final Project project
+
+        BuildInfo(Project project) {
+            hasGitRepository = project.file("${project.rootProject.projectDir}/.git").exists()
+            providedBuildId = project.properties.buildid?.trim() ?: System.getProperty('buildid')?.trim()
+            this.project = project
+
+            if(!hasGitRepository && providedBuildId == null) {
+                project.logger.error "Git repository not found and -Pbuildid / -Dbuilid was not specified."
+            }
+        }
+
+        String getRevisionInfo() {
+            if (hasGitRepository) {
+                OutputStream os = new ByteArrayOutputStream()
+                project.exec {
+                    standardOutput = os
+                    commandLine 'git','rev-parse', '--short', 'HEAD'
+                }
+                os.toString().trim()
+            } else  {
+                providedBuildId
+            }
+        }
+
+    }
+}

--- a/common/common.gradle
+++ b/common/common.gradle
@@ -1,33 +1,39 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 ext {
     ceylonModuleName = 'common'
     ceylonTestDisabled = true
 }
 
 apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"
+apply plugin : CeylonBuildInfoPlugin
 
 dependencies {
     compile 'org.tautua.markdownpapers:markdownpapers-core:1.2.7'
 }
 
-//"""
-//    <target name="compile.tests">
-//        <mkdir dir="${build.classes}" />
-//        <javac
-//            srcdir="${test.src}"
-//            destdir="${build.classes}"
-//            debug="true"
-//            encoding="UTF8"
-//            classpathref="test.run.classpath"
-//            target="${compile.java.target}"
-//            source="${compile.java.source}"
-//            bootclasspath="${compile.java.bootclasspath}">
-//            <include name="**/*.java" />
-//        </javac>
-//        <copy todir="${build.classes}">
-//            <fileset dir="${test.src}">
-//                <exclude name="**/*.java" />
-//            </fileset>
-//        </copy>
-//    </target>
-//"""
+ext {
+    generatedSrcDir = "${buildDir}/generated-java"
+    versionsTemplate = 'com/redhat/ceylon/common/Versions.java'
+}
 
+sourceSets {
+    main {
+        java {
+            exclude versionsTemplate
+            srcDir generatedSrcDir
+        }
+    }
+}
+
+task createVersionJava( type : Copy ) {
+    group "Build"
+    description "Creates Versions.java"
+    inputs.property 'revisionInfo', ceylonBuildInfo.revisionInfo
+    from 'src/' + versionsTemplate
+    into  generatedSrcDir
+    filter ReplaceTokens, tokens : [ commit : inputs.properties.revisionInfo ]
+    enabled = ceylonBuildInfo.hasGitRepository || ceylonBuildInfo.providedBuildId != null
+}
+
+compileJava.dependsOn createVersionJava

--- a/compiler-java/compilerjava.gradle
+++ b/compiler-java/compilerjava.gradle
@@ -223,11 +223,8 @@ task publishBootstrapModule( type : Copy ) {
     }
 
     from bootstrapModule
+    from bootstrapModuleXml
     into "${repoDir}/${cbp.'ceylon.bootstrap.dir'}"
-}
-
-publishJar {
-    from bootstrapModule
 }
 
 task publishJvmCompilerJars ( type : Copy ) {

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -1,5 +1,10 @@
 apply plugin : LifecycleBasePlugin
 apply plugin : CeylonBuildInfoPlugin
+apply plugin : CeylonCommonBuildProperties
+
+//ext {
+//    version = cbp.'ceylon-version'
+//}
 
 task setupRepo {
     group 'Distribution'
@@ -101,6 +106,34 @@ task publishInternal {
     dependsOn copyCompilerBinaries, copySupportFiles
     dependsOn installRuntime
     dependsOn generateBuildId
+}
+
+
+task zip ( type : Zip ) {
+
+    ext {
+
+    }
+    group "Publish"
+    description "Creates the distribution Zip"
+    from distDir, {
+        include '**'
+        exclude 'bin/ceylon*'
+    }
+    from distDir, {
+        include 'bin/*.plugin'
+    }
+    from distDir, {
+        include 'bin/ceylon*'
+        exclude 'bin/*.plugin'
+        fileMode 0755
+    }
+    into "ceylon-${version}"
+    destinationDir buildDir
+    version = "${project.version}-${ceylonBuildInfo.revisionInfo}"
+    baseName = 'ceylon'
+
+    enabled = ceylonBuildInfo.revisionInfo != null
 }
 
 

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -136,14 +136,21 @@ task zip ( type : Zip ) {
     enabled = ceylonBuildInfo.revisionInfo != null
 }
 
-
+task cleanRepo ( type : Delete ) {
+    group "clean"
+    description "Cleans the distribution area"
+    delete repoBinDir
+    delete repoLibDir
+    delete samplesDir
+    delete repoDir
+}
 
 // dist: publish,ide-quick
 // publish: clean-projects,install-all,copy-dist-bin,publish-quick
 // install-all: setup-repo, install-compiler, install-js, copy-compiler-binaries
 //               copy-samples, copy-templates, copy-contrib, copy-jvm-compiler-libraries,
 //               copy-licenses, install-runtime,
-//               add-module-descriptors, generate-buildid
+//               add-module-descriptors, generate-buildid <-- ALL DONE
 // ide-quick:
 // copy-dist-bin: DONE
 // publish-quick: DONE
@@ -153,15 +160,56 @@ task zip ( type : Zip ) {
 // copy-compiler-binaries: DONE
 // install-runtime: install-common,install-model,install-cmr,install-tool-provider,install-language,
 //                  install-java-main,install-runtime-nodeps <-- ALL DONE
-
-
-
-task cleanRepo ( type : Delete ) {
-    group "clean"
-    description "Cleans the distribution area"
-    delete repoBinDir
-    delete repoLibDir
-    delete samplesDir
-    delete repoDir
-}
+// copy-herd
+// test
+// test-quick (test-item)
+//
+// update:
+// status:
+// release:
+// nightly:
+// git-status:
+// git-update:
+//
+// package: clean-projects, install-all, generate-spec, generate-apidoc, generate-tooldoc,
+//          copy-dist-bin, zip
+//
+// osgi:
+// osgi-internal:
+// osgi-quick:
+// osgi-p2:
+// osgi-p2-internal:
+// osgi-p2-quick:
+//
+// generate-spec:
+// generate-apidoc:
+// generate--tooldoc:
+// generate-tooldoc-man:
+//
+// setup-sdk:
+// setup-admins-sdk:
+// status-sdk:
+// update-sdk:
+// clean-sdk:
+// sdk:
+//
+// setup-ide:
+// setup-admins-ide:
+// status-ide:
+// update-ide:
+// clean-ide:
+// ide
+// ide-quick (ide-item)
+//
+// eclipse:
+// eclipse-switch-to-last-release-updates:
+// eclipse-switch-back-to-master:
+// eclipse-rebuild-last-release-updates:
+//
+// intellij:
+//
+// status-all: status,status-sdk,status-ide
+// update-all: update,update-sdk,update-ide
+// clean-all: clean,clean-projects,clean-sdk,clean-ide
+// do-all: dist,sdk,eclipse
 

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -86,10 +86,11 @@ task copySupportFiles( type : Copy) {
     }
 }
 
+// TODO: Migrate this to a compiled task in buildSrc.
 task generateBuildId {
 
     group "Build"
-    description "Generates teh BUILDID file"
+    description "Generates the BUILDID file"
 
     ext {
         hasGitRepository = file("${rootProject.projectDir}/.git").exists()
@@ -150,12 +151,12 @@ task publishInternal {
 // ide-quick:
 // copy-dist-bin: DONE
 // publish-quick: DONE
-// setup-repo:
-// install-compiler:
-// install-js:
-// copy-compiler-binaries:
+// setup-repo: DONE
+// install-compiler: DONE
+// install-js: DONE
+// copy-compiler-binaries: DONE
 // install-runtime: install-common,install-model,install-cmr,install-tool-provider,install-language,
-//                  install-java-main,install-runtime-nodeps"
+//                  install-java-main,install-runtime-nodeps <-- ALL DONE
 
 
 

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -1,4 +1,5 @@
 apply plugin : LifecycleBasePlugin
+apply plugin : CeylonBuildInfoPlugin
 
 task setupRepo {
     group 'Distribution'
@@ -86,48 +87,10 @@ task copySupportFiles( type : Copy) {
     }
 }
 
-// TODO: Migrate this to a compiled task in buildSrc.
-task generateBuildId {
-
+task generateBuildId ( type : CeylonBuildIdGenerator ) {
     group "Build"
     description "Generates the BUILDID file"
-
-    ext {
-        hasGitRepository = file("${rootProject.projectDir}/.git").exists()
-        providedBuildId = project.properties.buildid ?: System.getProperty('buildid')
-        idFile = file("${distDir}/BUILDID")
-
-        getRevision = { OutputStream os->
-            if (hasGitRepository) {
-                project.exec {
-                    standardOutput = os
-                    commandLine 'git','rev-parse', '--short', 'HEAD'
-                }
-                os.toString()
-            } else if (providedBuildId) {
-                os << providedBuildId
-                providedBuildId
-            }
-        }
-    }
-
-
-    doFirst {
-        idFile.withOutputStream { os ->
-            getRevision(os)
-        }
-    }
-
-    outputs.upToDateWhen {
-        idFile.exists() && getRevision( new ByteArrayOutputStream() ) == idFile.text
-    }
-
-    outputs.file idFile
-    enabled = hasGitRepository || providedBuildId != null
-
-    if(!ext.hasGitRepository && ext.providedBuildId == null) {
-        logger.error "Git repository not found and -Pbuildid / -Dbuilid was not specified."
-    }
+    outputFile "${distDir}/BUILDID"
 }
 
 

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -2,10 +2,6 @@ apply plugin : LifecycleBasePlugin
 apply plugin : CeylonBuildInfoPlugin
 apply plugin : CeylonCommonBuildProperties
 
-//ext {
-//    version = cbp.'ceylon-version'
-//}
-
 task setupRepo {
     group 'Distribution'
     dependsOn ':runtime:setupRepo'
@@ -99,21 +95,13 @@ task generateBuildId ( type : CeylonBuildIdGenerator ) {
 }
 
 
-task publishInternal {
-    group 'Distribution'
-    description "Lifecycle task to cooridnate all internal publish tasks"
+task zip ( type : Zip ) {
+
     dependsOn setupRepo, installCompiler, installJS
     dependsOn copyCompilerBinaries, copySupportFiles
     dependsOn installRuntime
     dependsOn generateBuildId
-}
 
-
-task zip ( type : Zip ) {
-
-    ext {
-
-    }
     group "Publish"
     description "Creates the distribution Zip"
     from distDir, {
@@ -134,6 +122,12 @@ task zip ( type : Zip ) {
     baseName = 'ceylon'
 
     enabled = ceylonBuildInfo.revisionInfo != null
+}
+
+task publishInternal {
+    group 'Distribution'
+    description "Lifecycle task to coordinate all internal publish tasks"
+    dependsOn zip
 }
 
 task cleanRepo ( type : Delete ) {

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -38,8 +38,6 @@ Ant & Gradle builds.
 <7> `add-module-descriptors` is not handle in two ways. For Ceylon-specific artifacts this is part of the build
   in each subproject. For external artifacts this is indirectly covered by `:runtime:setupRepo`.
 
-In addition the `copy-dist-bin` Ant task is handled by
-
 .TODO
 * `ceylon-completion.bash` is copied twice - once in `copyContrib` and once in `copyCompilerBinaries`
 

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -241,7 +241,14 @@ a file can then be added to a JAR and/or be copied to the distribution area.
 Adds a number of configurations which can be used to configure the necessary OSGI metadata in way that is very
 specific to the Ceylon build. The file has been well documented and can be used as reference.
 
-===
+=== CeylonBuildInfoPlugin
+
+Provides capability to read commit info from Git repository or via a project property or via a system property,
+
+=== CeylonBuildIdGenerator
+
+A task for generating build identifier from Git
+
 == Custom build in gradle folder
 
 A number of common functionality not suitable for buildSrc have been added as buildscript in the `gradle` folder
@@ -366,21 +373,4 @@ extension block called `ceylon` but the configuration options are slightly diffe
 
 |===
 
-
-== Other items
-
-[quote,https://github.com/ceylon/ceylon/pull/6378#issuecomment-233606475]
-----
-Another thing is that the Ant build creates a BUILDID file in the distribution folder that contains the (short) Git commit id of the current HEAD of the Git repository that is being used to build things. The same ID is also replaced in the common/src/com/redhat/ceylon/common/Versions.java file.
-Look at the defcurrentcommit task in dist/build.xml for how we do that. (We run git rev-parse --short HEAD)
-But it should also be possible to define the buildid on the command line when executing the gradlew build command in case we're trying to build plain sources (not from a Git repository). In case of Ant we do this by passing -Dbuildid=XXXX on the command line.
-(We haven't done this for ant, but an error message if no Git repository was found and also no -Dbuildid was passed would be great)
-
-Also missing from the root distribution folder are: contrib, LICENSE-ASL, LICENSE-GPL-CP, NOTICE, README.md, samples and templates. These can simply be copied from dist.
-
-Hah, you actually improved something: in our distribution the bin/ceylon-compile-js.pluin file is missing!
-
-From my previous comment I failed to mention the dist/bin folder. It's contents should also be copied to the distribution's bin folder. (We're missing bin/ceylon-format.plugin)
-
-----
 

--- a/gradle/java-for-modules.gradle
+++ b/gradle/java-for-modules.gradle
@@ -54,10 +54,6 @@ dependencies {
 sourceCompatibility = cbp.'compile.java.source'
 targetCompatibility = cbp.'compile.java.target'
 
-compileJava {
-    options.encoding = 'UTF-8'
-}
-
 assemble {
     dependsOn 'sha1'
     dependsOn 'copyPluginFiles'
@@ -103,16 +99,6 @@ moduleXml {
             cbp."ceylon.${ceylonPublishModuleName}.dir").parentFile, '/_version_/module.xml')
     }
 }
-
-//jar {
-//    manifest {
-//        attributes 'Bundle-SymbolicName': bundleSymbolicName,
-//            'Bundle-Version': bundleVersionName+".${TimeStamp.BUILD}"
-//    }
-//    archiveName = "${bundleSymbolicName}-${bundleVersionName}.jar"
-//}
-
-
 
 jar {
     dependsOn moduleXml
@@ -221,5 +207,6 @@ if(ext.properties.containsKey('ceylonTestDisabled')) {
 afterEvaluate {
     tasks.withType(JavaCompile) { t ->
         t.options.compilerArgs ['-Xlint:-options']
+        t.options.encoding = 'UTF-8'
     }
 }

--- a/gradle/java-for-modules.gradle
+++ b/gradle/java-for-modules.gradle
@@ -24,6 +24,10 @@ if(!ext.properties.containsKey('ceylonPublishModuleName')) {
     ext.ceylonPublishModuleName = ceylonModuleName
 }
 
+if(!ext.properties.containsKey('ceylonNamespace')) {
+    ext.ceylonNamespace = 'com.redhat.ceylon'
+}
+
 // ----------------------------------------------------------------------------
 // Fail if prequisite properties are not in common-build.properties
 // ----------------------------------------------------------------------------
@@ -35,7 +39,7 @@ requiresCBP 'compile.java.source'
 
 ext {
     bundleVariant = ext.properties.containsKey('ceylonModuleVariant') ? ".${ceylonModuleVariant}" : ''
-    bundleSymbolicName = 'com.redhat.ceylon.' + ceylonModuleName + bundleVariant
+    bundleSymbolicName = ceylonNamespace + '.' + ceylonModuleName + bundleVariant
     bundleVersionName = cbp."module.com.redhat.ceylon.${ceylonModuleName}.version"
     archivePublishDir = "${repoDir}/" +  cbp."ceylon.${ceylonPublishModuleName}.dir"
 }

--- a/language/language.gradle
+++ b/language/language.gradle
@@ -33,8 +33,21 @@ task invokeAntBuild( type : GradleBuild ) {
 
 assemble.dependsOn invokeAntBuild
 
-task publishInternal {
-    dependsOn invokeAntBuild
+task languageModuleXml( type : CeylonBuildModuleXml ) {
+    description "Create module.xml for the language JAR"
+    sourceModule {
+        new File(project.file("${project(':runtime').projectDir}/dist/repo/" +
+            cbp."ceylon.language.dir").parentFile, '/_version_/module.xml')
+    }
+    destinationDir = {"${buildDir}/ceylon-module"}
+}
+
+
+task publishInternal( type : Copy ) {
+    dependsOn invokeAntBuild, languageModuleXml
+
+    from languageModuleXml
+    into "${repoDir}/${cbp.'ceylon.language.dir'}"
 }
 
 ['common','cli','model','cmr','compiler-java','langtools-classfile','typechecker','compiler-js'].each {

--- a/runtime/runtime.gradle
+++ b/runtime/runtime.gradle
@@ -128,6 +128,7 @@ task setupRepo( type : Copy ) {
     dependsOn addModuleDescriptorsForExternalDependencies
     into repoDir
     from externalDepsDestinationDir
+    exclude 'classes'
 }
 
 ['common','cmr','language','tool-provider','java-main'].each {

--- a/runtime/runtime.gradle
+++ b/runtime/runtime.gradle
@@ -64,6 +64,11 @@ task fakeClasseDirForExternalDependencies  {
     }
 }
 
+task sha1Externals( type : Checksum ) {
+    group "Build"
+    description "Create SHA1 checksum for external dependencies"
+}
+
 // Add tasks for each of the external JARs
 (fileTree('dist/repo') {
     include '**/*.jar'
@@ -109,6 +114,7 @@ task fakeClasseDirForExternalDependencies  {
         doFirst { mkdir manifest.classesDir }
     }
 
+    sha1Externals.archive osgiJar
     addModuleDescriptorsForExternalDependencies.dependsOn osgiJar, moduleTask
 }
 

--- a/runtime/runtime.gradle
+++ b/runtime/runtime.gradle
@@ -2,6 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 ext {
     ceylonModuleName = 'runtime'
+    ceylonNamespace = 'ceylon'
     ceylonSourceLayout = false
     ceylonTestDisabled = true
 }
@@ -10,7 +11,7 @@ apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"
 
 
 ext {
-    externalDepsDestinationDir = "${buildDir}/ceylon-runtime"
+    externalDepsDestinationDir = "${buildDir}/ceylon-externals"
 }
 
 dependencies {
@@ -115,7 +116,8 @@ task sha1Externals( type : Checksum ) {
     }
 
     sha1Externals.archive osgiJar
-    addModuleDescriptorsForExternalDependencies.dependsOn osgiJar, moduleTask
+    sha1Externals.dependsOn osgiJar
+    addModuleDescriptorsForExternalDependencies.dependsOn osgiJar, moduleTask, sha1Externals
 }
 
 assemble {


### PR DESCRIPTION
This is a smaller changeset mostly focused on fixing issues from #6394.

_Main features of this PR:_
- Fixed issues that found in #6394
  - `ceylon.runtime-1.2.3.jar` & co. was incorrectly created as `com.redhat.ceylon.runtime-xxxx`
  - Removed stray `ceylon-bootstrap-1.2.3.jar` in `distribution/repo/com/redhat/ceylon/compiler/java/1.2.3`
  - Eliminated tsray `classes` folder in `distribution/repo`
  - Added chesksums for 3rd party modules
- Fixed UTF-8 encoding issues that prevented build from completing on Windows
- Added `BUILDID` file
- Fixed `Versions.java`
- Added creation of distribution ZIP
- FIxed build failure in `language` which was causing a second build to be run.

_Outstanding:_
- `proxy-bundle`, `ide`, `sdk` (A good list exists within `dist.gradle`).
- A number of TODOs are still listed in gradle-migration.adoc.
- Tests are still disabled in most subprojects.

_Known issues:_
- `language` artifacts might still be missing OSGI information
