### PR TITLE
Improve #5098

### DIFF
--- a/language/runtime/com/redhat/ceylon/compiler/java/language/LazyIterable.java
+++ b/language/runtime/com/redhat/ceylon/compiler/java/language/LazyIterable.java
@@ -58,17 +58,12 @@ extends BaseIterable<Element, Absent>{
                 return finished_.get_();
             }
 
-            while (true) {
-                if (rest instanceof LazyIterable.LazyIterator) {
-                    LazyIterable<Element, ?>.LazyIterator lazyRest =
-                            (LazyIterable<Element, ?>.LazyIterator) rest;
-                    Iterator<? extends Element> replacement = lazyRest.flatten();
-                    if (replacement != null) {
-                        rest = replacement;
-                    }
-                    else {
-                        break;
-                    }
+            while (rest instanceof LazyIterable.LazyIterator) {
+                LazyIterable<Element, ?>.LazyIterator lazyRest =
+                        (LazyIterable<Element, ?>.LazyIterator) rest;
+                Iterator<? extends Element> replacement = lazyRest.flatten();
+                if (replacement != null) {
+                    rest = replacement;
                 }
                 else {
                     break;

--- a/language/runtime/com/redhat/ceylon/compiler/java/language/LazyIterable.java
+++ b/language/runtime/com/redhat/ceylon/compiler/java/language/LazyIterable.java
@@ -17,45 +17,45 @@ import com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor;
  */
 public abstract class LazyIterable<Element, Absent> 
 extends BaseIterable<Element, Absent>{
-	
+    
     private final class LazyIterator 
     extends BaseIterator<Element> {
-    	
-	    int index = 0;
-	    Iterator<? extends Element> rest = null;
-	    
-	    private LazyIterator() {
-		    super($reifiedElement);
-	    }
-	    
-	    @SuppressWarnings({ "unchecked" })
-	    @Override
-	    public Object next() {
-	        if (rest != null) {
-	            return rest.next();
-	        } 
-	        else if (index >= $numExpressions) {
-	            return finished_.get_();
-	        }
-	        else {
-	        	Object result = $evaluate$(index++);
-	        	if ($spread && index == $numExpressions) {
-	        		Iterable<? extends Element, ?> iterable = 
-	        				(Iterable<? extends Element,?>) result;
-	        		rest = iterable.iterator();
-	        		result = rest.next();
-	        	}
-	        	return result;
-	        }
-	    }
-	    
-	    @Override
-	    public String toString() {
-	    	return LazyIterable.this.toString() + ".iterator()";
-	    }
+        
+        int index = 0;
+        Iterator<? extends Element> rest = null;
+        
+        private LazyIterator() {
+            super($reifiedElement);
+        }
+        
+        @SuppressWarnings({ "unchecked" })
+        @Override
+        public Object next() {
+            if (rest != null) {
+                return rest.next();
+            } 
+            else if (index >= $numExpressions) {
+                return finished_.get_();
+            }
+            else {
+                Object result = $evaluate$(index++);
+                if ($spread && index == $numExpressions) {
+                    Iterable<? extends Element, ?> iterable = 
+                            (Iterable<? extends Element,?>) result;
+                    rest = iterable.iterator();
+                    result = rest.next();
+                }
+                return result;
+            }
+        }
+        
+        @Override
+        public String toString() {
+            return LazyIterable.this.toString() + ".iterator()";
+        }
     }
     
-	private final TypeDescriptor $reifiedElement;
+    private final TypeDescriptor $reifiedElement;
     private final int $numExpressions;
     private final boolean $spread;
     
@@ -90,7 +90,7 @@ extends BaseIterable<Element, Absent>{
         else if ($spread) {
             // do we have at least one non-spread expression?
             return $numExpressions > 1 ? 
-            		false : super.getEmpty(); // with spread we just don't know
+                    false : super.getEmpty(); // with spread we just don't know
         }
         else{
             // we have at least one non-spread expression
@@ -113,7 +113,7 @@ extends BaseIterable<Element, Absent>{
             return super.longerThan(length);
         }
         else {
-        	return $numExpressions > length;
+            return $numExpressions > length;
         }
     }
     
@@ -123,7 +123,7 @@ extends BaseIterable<Element, Absent>{
             return super.shorterThan(length);
         }
         else {
-        	return $numExpressions < length;
+            return $numExpressions < length;
         }
     }
     


### PR DESCRIPTION
On the JVM, this helps, but does not completely resolve #5098.

For the benchmarking code below (after warmup), the old implementation returned:

```
[52364706, 5000]
Exception in thread "main" java.lang.StackOverflowError
```

and with this patch:

```
[158346, 5000]
[30148426, 500000]
```

(the first number is nanos, the second is the size of the Iterable).

``` ceylon
[Integer, Result] time<Result>(Result() f, Integer repeat = 1) {
    "repeat must be at least 1"
    assert (repeat >= 1);

    value start = system.nanoseconds;
    value result = f();
    for (i in 0:repeat-1) {
        f();
    }
    value nanos = system.nanoseconds - start;
    return [nanos, result];
}

shared void run() {
    function work(Integer size)() {
        variable {Integer+} it = {1};
        for (i in 2:size-1) {
            it = it.follow(i);
        }
        variable value count = 0;
        it.each((_) { count++; });
        return count;
    }

    print(time(work(5k)));
    print(time(work(500k)));
}
```
