### PR TITLE
Restructuring Gradle Build #5 - 

### DIFF
--- a/ant-plugin/antplugin.gradle
+++ b/ant-plugin/antplugin.gradle
@@ -1,0 +1,41 @@
+apply plugin : CeylonCommonBuildProperties
+apply plugin: 'java'
+
+sourceCompatibility = cbp.'compile.java.source'
+targetCompatibility = cbp.'compile.java.target'
+
+dependencies {
+    compile project(':cli')
+    compile antDep
+    testCompile junitDep
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = [ "${project(':compiler-java').projectDir}/src","${project(':common').projectDir}/src"]
+            include 'com/redhat/ceylon/ant/**'
+            include 'com/redhat/ceylon/common/**'
+            include 'com/redhat/ceylon/launcher/**'
+            exclude 'com/redhat/ceylon/common/log/**'
+        }
+        resources {
+            srcDirs = [ "${project(':compiler-java').projectDir}/src","${project(':common').projectDir}/src"]
+            include "com/redhat/ceylon/ant/antlib.xml"
+            include "com/redhat/ceylon/common/config/messages.properties"
+        }
+    }
+}
+
+jar {
+    description 'Create Ant tasks jar'
+    archiveName = 'ceylon-ant.jar'
+}
+
+task publishInternal( type : Copy ) {
+    group 'Distribution'
+    description 'Copies binary artifacts to distribution area'
+    from jar
+    into repoLibDir
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,6 @@ subprojects {
     version= cbp.'ceylon.version'
 
     repositories {
-        flatDir {
-            dirs "${rootProject.projectDir}/lib"
-        }
         jcenter()
         mavenCentral()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -66,11 +66,10 @@ task 'clean-all' {
     group "ceylon cross project"
     description "Cleans everything here and in linked projects"
     dependsOn clean
-//    dependsOn 'clean-sdk'
+    dependsOn 'clean-sdk'
 //    dependsOn 'clean-ide'
 }
 
-/*
 task 'clean-sdk' {
     group "ceylon cross project"
     description "Cleans the SDK"
@@ -83,6 +82,7 @@ task sdk {
     dependsOn ':ceylon-sdk:publishInternal'
 }
 
+/*
 //clean-sdk - calls ant clean in the ../ceylon-sdk folder
 //    sdk - calls ant publish ide-quick in the ../ceylon-sdk folder
 //clean-ide - calls ant clean in the ../ceylon-.formatter, ../ceylon.tool.converter.java2ceylon, ../ceylon-ide-common, ../ceylon-ide-eclipse and ../ceylon-ide-intellij folders

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ buildScan {
 }
 
 allprojects {
+    apply from : "${rootProject.projectDir}/dependencies.gradle"
+
     ext {
         buildPrefix = 'builtByGradle'
     }
@@ -40,6 +42,13 @@ subprojects {
     repositories {
         jcenter()
         mavenCentral()
+    }
+
+    afterEvaluate {
+        tasks.withType(JavaCompile) { t ->
+            t.options.compilerArgs ['-Xlint:-options']
+            t.options.encoding = 'UTF-8'
+        }
     }
 }
 

--- a/ceylon-bootstrap/bootstrap.gradle
+++ b/ceylon-bootstrap/bootstrap.gradle
@@ -1,0 +1,38 @@
+apply plugin : CeylonCommonBuildProperties
+apply plugin: 'java'
+
+sourceCompatibility = '1.6'
+targetCompatibility = '1.6'
+
+dependencies {
+    compile project(':common')
+    testCompile junitDep
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = [ "${project(':compiler-java').projectDir}/src"/*,"${project(':common').projectDir}/src"*/]
+            include "com/redhat/ceylon/launcher/Bootstrap*"
+            include "com/redhat/ceylon/launcher/CeylonClassLoader*"
+            include "com/redhat/ceylon/launcher/LauncherUtil*"
+        }
+    }
+}
+
+jar {
+    description 'Create bootstrap jar'
+    archiveName = 'ceylon-bootstrap.jar'
+    manifest {
+        attributes 'Manifest-Version': 1.0,
+            'Main-Class': 'com.redhat.ceylon.launcher.Bootstrap'
+    }
+}
+
+task publishInternal( type : Copy ) {
+    group 'Distribution'
+    description 'Copies binary artifacts to distribution area'
+    from jar
+    into repoLibDir
+}
+

--- a/cmr/cmr.gradle
+++ b/cmr/cmr.gradle
@@ -2,7 +2,7 @@
 ext {
     ceylonModuleName = 'module-resolver'
     ceylonSourceLayout = false
-//    ceylonTestDisabled = true
+    ceylonTestDisabled = true
 }
 
 apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"

--- a/cmr/cmr.gradle
+++ b/cmr/cmr.gradle
@@ -2,7 +2,7 @@
 ext {
     ceylonModuleName = 'module-resolver'
     ceylonSourceLayout = false
-    ceylonTestDisabled = true
+//    ceylonTestDisabled = true
 }
 
 apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"
@@ -39,6 +39,11 @@ sourceSets {
     }
 }
 
+
+test {
+    // there are '@Suite.SuiteClasses` in this test set - only run them.
+    include '**/AllCmrTests.class'
+}
 
 ['common','model','cmr-aether','cmr-webdav','cmr-js'].each {
     publishInternal.dependsOn ":${it}:publishInternal"

--- a/common/common.gradle
+++ b/common/common.gradle
@@ -2,7 +2,6 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 ext {
     ceylonModuleName = 'common'
-    ceylonTestDisabled = true
 }
 
 apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"

--- a/compiler-java/compilerjava.gradle
+++ b/compiler-java/compilerjava.gradle
@@ -2,8 +2,8 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 ext {
     ceylonModuleName = 'compiler'
-    ceylonTestDisabled = true
     ceylonModuleVariant = 'java'
+    ceylonTestDisabled = true
 }
 
 apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"
@@ -17,13 +17,31 @@ dependencies {
     compile project(':model')
     compile project(':cmr')
     compile project(':typechecker')
-    compile 'org.apache.ant:ant:1.8.2'
-    compile 'com.github.rjeschke:txtmark:0.13'
-    compile 'org.antlr:antlr:3.4'
+    compile antDep
+    compile txtmarkDep
+    compile antlrDep
 
-    testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'
-    testCompile group: 'org.tautua.markdownpapers', name: 'markdownpapers-core', version: '1.2.7'
-    testCompile group: 'org.jboss.modules', name: 'jboss-modules', version: '1.4.4.Final'
+//    testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'
+    testCompile markdownPapersDep
+    testCompile jbossDep
+
+    testRuntime project(':cmr-webdav')
+    testRuntime project(':cmr-aether')
+    testRuntime sardineDep
+    testRuntime apacheCommonsCodecDep
+    testRuntime apacheCommonsLoggingDep
+    testRuntime jsonSmartDep
+//    <pathelement path="${ceylon.compiler.lib}" />
+//    <pathelement path="${ceylon.language.lib}" />
+//    <pathelement path="${ceylon-tests.car}" />
+//    <pathelement path="${maven-support.lib}" />
+//    <pathelement path="${shrinkwrap-maven-uberjar.lib}" />
+//    <pathelement path="${jboss-logmanager.lib}" />
+//    <pathelement path="${slf4j-simple.lib}" />
+//    <pathelement path="${slf4j-api.lib}" />
+//    <pathelement path="${sardine.lib}" />
+//    <pathelement path="${httpcore.lib}" />
+//    <pathelement path="${httpclient.lib}" />
 }
 
 sourceSets {
@@ -48,16 +66,16 @@ sourceSets {
         }
     }
 
-    antTask {
-        java {
-            srcDirs = []
-        }
-        resources {
-            srcDirs = [ 'src',"${project(':common').projectDir}/src"]
-            include "com/redhat/ceylon/ant/antlib.xml"
-            include "com/redhat/ceylon/common/config/messages.properties"
-        }
-    }
+//    antTask {
+//        java {
+//            srcDirs = []
+//        }
+//        resources {
+//            srcDirs = [ 'src',"${project(':common').projectDir}/src"]
+//            include "com/redhat/ceylon/ant/antlib.xml"
+//            include "com/redhat/ceylon/common/config/messages.properties"
+//        }
+//    }
 
     test {
         java {
@@ -133,40 +151,6 @@ jar {
 }
 
 
-task antJar ( type : Jar ) {
-    group 'Build'
-    description 'Create Ant tasks jar'
-    dependsOn classes,processAntTaskResources
-
-    destinationDir = jar.destinationDir
-    archiveName = 'ceylon-ant.jar'
-    from sourceSets.main.output.classesDir, {
-        include "com/redhat/ceylon/ant/**"
-        include "com/redhat/ceylon/common/**"
-        include "com/redhat/ceylon/launcher/**"
-        exclude "com/redhat/ceylon/common/log/*.class"
-    }
-    from sourceSets.antTask.output.resourcesDir
-}
-
-task bootstrapJar( type : Jar ) {
-    group 'Build'
-    description 'Create bootstrap jar'
-    dependsOn classes, processResources
-    destinationDir = jar.destinationDir
-    archiveName = 'ceylon-bootstrap.jar'
-    from sourceSets.main.output.classesDir, {
-        include "com/redhat/ceylon/launcher/Bootstrap*.class"
-        include "com/redhat/ceylon/launcher/CeylonClassLoader.class"
-        include "com/redhat/ceylon/launcher/LauncherUtil.class"
-    }
-
-    manifest {
-        attributes 'Manifest-Version': 1.0,
-            'Main-Class': 'com.redhat.ceylon.launcher.Bootstrap'
-    }
-}
-
 task bootstrapModuleXml( type : CeylonBuildModuleXml ) {
     description "Create module.xml for the bootstrap JAR"
     sourceModule {
@@ -227,16 +211,7 @@ task publishBootstrapModule( type : Copy ) {
     into "${repoDir}/${cbp.'ceylon.bootstrap.dir'}"
 }
 
-task publishJvmCompilerJars ( type : Copy ) {
-    group "Distribution"
-    description "Copy bootstrap & Ant jars to distribution area"
-    from bootstrapJar
-    from antJar
-    into repoLibDir
-}
-
 publishInternal {
-    dependsOn publishJvmCompilerJars
     dependsOn publishBootstrapModule
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,50 @@
+ext {
+    mavenVer       = '3.3.9'
+    mavenAetherVer = '1.1.0'
+    slf4jVer       = '1.6.1'
+
+    antDep                  = 'org.apache.ant:ant:1.8.2'
+    antlrDep                = 'org.antlr:antlr:3.4' // complete
+    apacheCommonsCodecDep   = 'commons-codec:commons-codec:1.8'
+    apacheCommonsLoggingDep = 'commons-logging:commons-logging:1.1.1'
+    jbossDep                = 'org.jboss.modules:jboss-modules:1.4.4.Final'
+//    jbossShrinkwrapDep      = ':1.0.0.cr-1' // api, impl-base, spi
+    // org.jboss:jandex:2.0.0.Final
+    jsonSmartDep            = 'net.minidev:json-smart:1.1.1'
+    junitDep                = 'junit:junit:4.11.0'
+    markdownPapersDep       = 'org.tautua.markdownpapers:markdownpapers-core:1.2.7'
+    mavenAetherApiDep       = "org.eclipse.aether:aether-api:${mavenAetherVer}"
+    mavenAetherConnectorDep = "org.eclipse.aether:aether-connector-basic:${mavenAetherVer}"
+    mavenAetherImplDep      = "org.eclipse.aether:aether-impl:${mavenAetherVer}"
+//    mavenAetherSpiDep       = ":${mavenAetherVer}"
+    mavenAetherTransFileDep = "org.eclipse.aether:aether-transport-file:${mavenAetherVer}"
+    mavenAetherTransHttpDep = "org.eclipse.aether:aether-transport-http:${mavenAetherVer}"
+//    mavenAetherUtilDep      = ":${mavenAetherVer}"
+    sardineDep              = 'com.github.lookfirst:sardine:5.1'
+    slf4jApiDep             = "org.slf4j:slf4j-api:${slf4jVer}"
+    slf4jSimpleDep          = "org.slf4j:slf4j-simple:${slf4jVer}"
+    txtmarkDep              = 'com.github.rjeschke:txtmark:0.13'
+}
+
+
+//maven-artifact.lib=${runtime.repo.path}/org/apache/maven/maven-artifact/${maven.version}/org.apache.maven.maven-artifact-${maven.version}.jar
+//maven-model.lib=${runtime.repo.path}/org/apache/maven/maven-model/${maven.version}/org.apache.maven.maven-model-${maven.version}.jar
+//maven-model-builder.lib=${runtime.repo.path}/org/apache/maven/maven-model-builder/${maven.version}/org.apache.maven.maven-model-builder-${maven.version}.jar
+//maven-repository-metadata.lib=${runtime.repo.path}/org/apache/maven/maven-repository-metadata/${maven.version}/org.apache.maven.maven-repository-metadata-${maven.version}.jar
+//maven-builder-support.lib=${runtime.repo.path}/org/apache/maven/maven-builder-support/${maven.version}/org.apache.maven.maven-builder-support-${maven.version}.jar
+//maven-settings.lib=${runtime.repo.path}/org/apache/maven/maven-settings/${maven.version}/org.apache.maven.maven-settings-${maven.version}.jar
+//maven-settings-builder.lib=${runtime.repo.path}/org/apache/maven/maven-settings-builder/${maven.version}/org.apache.maven.maven-settings-builder-${maven.version}.jar
+//maven-aether-provider.lib=${runtime.repo.path}/org/apache/maven/maven-aether-provider/${maven.version}/org.apache.maven.maven-aether-provider-${maven.version}.jar
+//
+//plexus-interpolation.lib=${runtime.repo.path}/org/codehaus/plexus/plexus-interpolation/1.22/org.codehaus.plexus.plexus-interpolation-1.22.jar
+//plexus-utils.lib=${runtime.repo.path}/org/codehaus/plexus/plexus-utils/3.0.22/org.codehaus.plexus.plexus-utils-3.0.22.jar
+//
+//guava.lib=${runtime.repo.path}/com/google/guava/18.0/com.google.guava-18.0.jar
+//commons-lang3.lib=${runtime.repo.path}/org/apache/commons/lang3/3.4/org.apache.commons.lang3-3.4.jar
+//
+//maven-support.lib=${aether-api.lib}:${aether-spi.lib}:${aether-util.lib}:${aether-impl.lib}:\
+// ${aether-connector-basic.lib}:${aether-transport-file.lib}:${aether-transport-http.lib}:\
+// ${maven-artifact.lib}:${maven-model.lib}:${maven-model-builder.lib}:${maven-repository-metadata.lib}:${maven-builder-support.lib}:\
+// ${maven-settings.lib}:${maven-settings-builder.lib}:${maven-aether-provider.lib}:\
+// ${plexus-interpolation.lib}:${plexus-utils.lib}:\
+// ${guava.lib}:${commons-lang3.lib}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,8 +2,10 @@ ext {
     mavenVer       = '3.3.9'
     mavenAetherVer = '1.1.0'
     slf4jVer       = '1.6.1'
+    bndVer         = '3.2.0'
 
     antDep                  = 'org.apache.ant:ant:1.8.2'
+    antContribDep           = 'ant-contrib:ant-contrib:1.0b3'
     antlrDep                = 'org.antlr:antlr:3.4' // complete
     apacheCommonsCodecDep   = 'commons-codec:commons-codec:1.8'
     apacheCommonsLoggingDep = 'commons-logging:commons-logging:1.1.1'
@@ -20,12 +22,14 @@ ext {
     mavenAetherTransFileDep = "org.eclipse.aether:aether-transport-file:${mavenAetherVer}"
     mavenAetherTransHttpDep = "org.eclipse.aether:aether-transport-http:${mavenAetherVer}"
 //    mavenAetherUtilDep      = ":${mavenAetherVer}"
+    osgiBindexDep           = ":org.osgi.impl.bundle.bindex:2.2.0"
+    osgiBndDep              = "biz.aQute.bnd:biz.aQute.bnd:${bndVer}"
+    osgiBndAntDep           = "biz.aQute.bnd:org.osgi.impl.bundle.repoindex.ant:${bndVer}"
     sardineDep              = 'com.github.lookfirst:sardine:5.1'
     slf4jApiDep             = "org.slf4j:slf4j-api:${slf4jVer}"
     slf4jSimpleDep          = "org.slf4j:slf4j-simple:${slf4jVer}"
     txtmarkDep              = 'com.github.rjeschke:txtmark:0.13'
 }
-
 
 //maven-artifact.lib=${runtime.repo.path}/org/apache/maven/maven-artifact/${maven.version}/org.apache.maven.maven-artifact-${maven.version}.jar
 //maven-model.lib=${runtime.repo.path}/org/apache/maven/maven-model/${maven.version}/org.apache.maven.maven-model-${maven.version}.jar

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -4,7 +4,7 @@ apply plugin : CeylonCommonBuildProperties
 
 task setupRepo {
     group 'Distribution'
-    dependsOn ':runtime:setupRepo'
+    dependsOn ':runtime-externals:setupRepo'
     dependsOn ':runtime:publishInternal'
 }
 

--- a/dist/dist.gradle
+++ b/dist/dist.gradle
@@ -17,6 +17,8 @@ task installCompiler {
     dependsOn ':cmr:publishInternal'
     dependsOn ':typechecker:publishInternal'
     dependsOn ':compiler-java:publishInternal'
+    dependsOn ':ant-plugin:publishInternal'
+    dependsOn ':ceylon-bootstrap:publishInternal'
     mustRunAfter setupRepo
 }
 

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -280,7 +280,7 @@ Gradle lifecycle tasks to appropriate ones in the Ant build.
 | `common` | Working
 | `langtools-classfile | No tests
 | `model` | Working
-| `cmr` | Disabled (17 failing tests).
+| `cmr` | Disabled (2 failing tests - 6 more is run by JDK8).
 | `cli` | Working
 | `compiler-java` | Disabled (compilation failures)
 | `compiler-js` | Disabled (Most tests fail with `LanguageModuleNotFoundException`).
@@ -294,7 +294,7 @@ Gradle lifecycle tasks to appropriate ones in the Ant build.
 [[OSGIheaders]]
 == Generating OSGI headers
 
-In order to deal with OSGI headers, the  GRadle `osgi` plugin is applied and a custom task extension is
+In order to deal with OSGI headers, the  GRradle `osgi` plugin is applied and a custom task extension is
 added to the 'jar` task. This is activated by applying the `CeylonBuildOsgiPlugin`. Other Jar tasks can have this
 fucntionality actived by adding `setAsOsgiExternalArchive()` (for external artifcats) or
 `setAsOsgiArchive()` (for  Ceylon-specific artifacts) to the configuration block. Both cases enable a new

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -62,12 +62,14 @@ Needed a special `sourceSet` layout.
 As all of the four Ant `javac` tasks ended up in a single JAR and used the same compilation options,
  I think putting them into a single compilation task was the way to go.
 
-In an earlier https://github.com/ceylon/ceylon/pull/6378[#6378] restructuring effort there was an
-issue with stray `_version_` folders be left around.
-This problem has now been eliminated due to the new way that <<OSGIHeader,OSGi headers>> are being added.
+* What about those `pom.xml` files that are dotted over the place?
+
+=== Runtime-external
+
+This a restructuring from `runtime` which looks after the external runtime dependencies. This just allows
+for a cleaner build.
 
 .TODO
-* What about those `pom.xml` files that are dotted over the place?
 * Should look to see if we cannot handle the JARs via Gradle's dependency mechanism.
 
 === Cli

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -277,7 +277,7 @@ Gradle lifecycle tasks to appropriate ones in the Ant build.
 | `cmr-aether` | No tests
 | `cmr-js` | No tests
 | `cmd-webdav` | No tests
-| `common` | Disabled (Fails in `RepositoryTest`)
+| `common` | Working
 | `langtools-classfile | No tests
 | `model` | Working
 | `cmr` | Disabled (17 failing tests).

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -282,7 +282,7 @@ Gradle lifecycle tasks to appropriate ones in the Ant build.
 | `model` | Working
 | `cmr` | Disabled (2 failing tests - 6 more is run by JDK8).
 | `cli` | Working
-| `compiler-java` | Disabled (compilation failures)
+| `compiler-java` | Disabled (compilation failures). Similar issue with `ant test`.
 | `compiler-js` | Disabled (Most tests fail with `LanguageModuleNotFoundException`).
 | `module-loader` | No tests
 | `runtime` | Disabled (requires updates to Gradle script)

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -169,6 +169,16 @@ for a cleaner build.
 .TODO
 * Should look to see if we cannot handle the JARs via Gradle's dependency mechanism.
 
+=== Sdk-build
+
+Newly added subproject to wrap around SDK building. It used the top-level build.gradle to setup a correct environment
+for the Ant Build and uses a Git plugin for Gradle to handle updates etc. A second level build (`ant.gradle`) loads the
+Ant Build and executed it once the appropriate properties for Ant as been setup.
+
+.TODO
+* The current Git plugin that is being used does a `git pull` instead of `git pull --rebase`. Waiting on
+https://github.com/seu-as-code/seu-as-code.plugins/issues/26[seu-as-code.plugins #26] to be fixed.
+
 === Tool-provider
 
 It needed a special configuration to pick up the `car` file from `language`.

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -13,6 +13,78 @@ Ant & Gradle builds.
 
 == Subprojects
 
+=== Ant-plugin
+
+This is the first action at restructuring the `compiler-java` build. All of the sources are still in the
+`java-compiler` source area, but the ANT plugin is now build separately with artifacts ending up in it's own
+build directory without polluting the `compiler-java` area. This has simplified the `compiler-java` build as well.
+
+=== Ceylon-bootstrap
+
+This is the second action at restructuring the `compiler-java` build. All of the sources are still in the
+`java-compiler` source area, but the bootrstao JAR is now build separately with artifacts ending up in it's own
+build directory without polluting the `compiler-java` area. This has simplified the `compiler-java` build as well.
+
+=== Cli
+
+.TODO
+* Should consider looking at `application` plugins to do a better job of bundling scripts. One task is
+  specifically called `startScripts` to mimic a similar fucntionaing task in `application` plugin. This
+  was done to deliberately break the build when the refactoring for `application` happens.
+
+=== Cmr
+
+.TODO
+* 17 tests are currently (disabled test task for moment)
+
+=== Cmr-aether
+
+Standard Ceylon Java project.
+
+=== Cmr-webdav
+
+Standard Ceylon Java project.
+
+=== Commons
+
+.From common/build.xml
+[source,xml]
+----
+<target name="publish"
+    depends="clean.repo,init.repo,dist,publish-internal" <!-- 1 --> <!-- 2 --> <!-- 3 -- >
+    description="Publish both type checker and ceylon.language template module">
+</target>
+----
+<1> `clean.repo` handled by `cleanRepo` which is a dependency of `clean`.
+<2> `init.repo`, `publish-internal` handled by `publishInternal`.
+<3> `dist` handled by Gradle dependency chain and included `assemble`, `sourceZip`, `sha1` and `jar`
+
+=== Compiler-java
+
+There is an unfortunate interdependency with `language`.
+
+*Utf8properties*: Unlike the Ant `compiler.classes` the `main` source set will include `*.utf8properties`.
+  The reason for this is that the Gradle task can take care of this in the `processResources` task via a filter,
+  whereas in Ant this hand to be handled via an extra build step.
+
+.TODO
+* Do we need to `-XDignore.symbol.file` when compiling?
+* Mismatch in `compiler-*.jar` artifacts between ANT (1789 files) and Gradle (1777 files).
+* Mismatch in `ceylon-ant.jar` artifacts between ANT (154 files) and Gradle (155 files).
+* For `bootstrap-ant.jar` need to check `MANIFEST.MF`
+
+=== Compiler-js
+
+The directory layout seems to be nearer to a Gradle/Maven convention, but the resources are still
+under `src/main/java`. For this reason there is a `sourceSets` block in the build to find the correct files.
+If those files could simply be moved to the `src/main/resources` folder the whole block can be eliminated.
+
+.TODO
+* Do we need to include test classs fo the `ceylon.language.js`?
+* Not sure about the runtime directory.
+  Should we send those artifacts to `build/libs` or `build/runtime` under Gradle?
+* `jdk5Stubs` seems to refer to an empty collection. We could get rid of it and simplify the build script.
+
 === Dist
 
 .From dist/build.xml
@@ -42,19 +114,43 @@ Ant & Gradle builds.
 .TODO
 * `ceylon-completion.bash` is copied twice - once in `copyContrib` and once in `copyCompilerBinaries`
 
-=== Commons
 
-.From common/build.xml
-[source,xml]
-----
-<target name="publish"
-    depends="clean.repo,init.repo,dist,publish-internal" <!-- 1 --> <!-- 2 --> <!-- 3 -- >
-    description="Publish both type checker and ceylon.language template module">
-</target>
-----
-<1> `clean.repo` handled by `cleanRepo` which is a dependency of `clean`.
-<2> `init.repo`, `publish-internal` handled by `publishInternal`.
-<3> `dist` handled by Gradle dependency chain and included `assemble`, `sourceZip`, `sha1` and `jar`
+=== Java-main
+
+.TODO
+* Do we need to set the compiler flag `-XDignore.symbol.file` ?
+
+=== Langtools-classfile
+
+This has been straight-forward to do. There are no `*.utf8properties` files in this project, but it has alerted to the
+`native2ascii` Ant task that was used. The solution (which hopefully will work) is to hook into the lifecycle
+`processResources` task, and fix the encodings on the fly using the Ant `EscapeUnicode` filter instead.
+
+We also set `ceylonPublishModuleName` as this one uses two distinctly named property names from `common-build.properties`.
+
+.TODO
+* Do we need to set `-XDignore.symbol.file`  for `JavaCompile` options?
+
+=== Language
+
+We still use the imported Ant build to get stuff done. `build.dir` is set as a property on the imported build
+and that seems to be forcing Ant to build into Gradle's `buildDir`.
+
+There is an unfortunate interdependency with `compiler-java`.
+
+.TODO
+* Fix it from going through the Ant build to building everything as part of Gradle direct.
+* Start using `generate-source.gradle` to generate source.
+* Set `generateModuleInfo` according to `jigsaw`.
+* Some copy operations in the Ant `build` task need to be investigated.
+
+=== Model
+
+Standard Ceylon Java project.
+
+=== Module-loader
+
+It needed a special configuration to pick up the `car` file from `language`.
 
 === Runtime
 
@@ -73,40 +169,18 @@ for a cleaner build.
 .TODO
 * Should look to see if we cannot handle the JARs via Gradle's dependency mechanism.
 
-=== Cli
+=== Tool-provider
+
+It needed a special configuration to pick up the `car` file from `language`.
+
+There is a `sourceSets` block in the build to find the correct resources files.
+If those files could simply be moved to the `src/main/resources` folder the whole block can be eliminated.
+
+Note that unlike the Ant build, the `*.utf8properties` are included in the block as the `processResources` task
+knows how to take care of them.
 
 .TODO
-* Should consider looking at `application` plugins to do a better job of bundling scripts. One task is
-  specifically called `startScripts` to mimic a similar fucntionaing task in `application` plugin. This
-  was done to deliberately break the build when the refactoring for `application` happens.
-
-=== Cmr
-
-.TODO
-* 17 tests are currently (disabled test task for moment)
-
-=== Cmr-aether
-
-Standard Ceylon Java project.
-
-=== Cmr-webdav
-
-Standard Ceylon Java project.
-
-=== Model
-
-Standard Ceylon Java project.
-
-=== Langtools-classfile
-
-This has been straight-forward to do. There are no `*.utf8properties` files in this project, but it has alerted to the
-`native2ascii` Ant task that was used. The solution (which hopefully will work) is to hook into the lifecycle
-`processResources` task, and fix the encodings on the fly using the Ant `EscapeUnicode` filter instead.
-
-We also set `ceylonPublishModuleName` as this one uses two distinctly named property names from `common-build.properties`.
-
-.TODO
-* Do we need to set `-XDignore.symbol.file`  for `JavaCompile` options?
+* Do we need to set the compiler flag `-XDignore.symbol.file` ?
 
 === Typechecker
 
@@ -129,67 +203,6 @@ starts to work.
 
 .TODO
 * The Ant `antlr.tree` deleted tokens at the end. Should we still do that?
-
-=== Compiler-java
-
-There is an unfortunate interdependency with `language`.
-
-*Utf8properties*: Unlike the Ant `compiler.classes` the `main` source set will include `*.utf8properties`.
-  The reason for this is that the Gradle task can take care of this in the `processResources` task via a filter,
-  whereas in Ant this hand to be handled via an extra build step.
-
-.TODO
-* Do we need to `-XDignore.symbol.file` when compiling?
-* Mismatch in `compiler-*.jar` artifacts between ANT (1789 files) and Gradle (1777 files).
-* Mismatch in `ceylon-ant.jar` artifacts between ANT (154 files) and Gradle (155 files).
-* For `bootstrap-ant.jar` need to check `MANIFEST.MF`
-
-=== Language
-
-We still use the imported Ant buidl to get stuff done. `build.dir` is set as a property on the imported build
-and that seems to be forcing Ant to build into Gradle's `buildDir`.
-
-There is an unfortunate interdependency with `compiler-java`.
-
-.TODO
-* Fix it from going through the Ant build to building everything as part of Gradle direct.
-* Start using `generate-source.gradle` to generate source.
-* Set `generateModuleInfo` according to `jigsaw`.
-* Some copy operations in the Ant `build` task need to be investigated.
-
-=== Compiler-js
-
-The directory layout seems to be nearer to a Gradle/Maven convention, but the resources are still
-under `src/main/java`. For this reason there is a `sourceSets` block in the build to find the correct files.
-If those files could simply be moved to the `src/main/resources` folder the whole block can be eliminated.
-
-.TODO
-* Do we need to include test classs fo the `ceylon.language.js`?
-* Not sure about the runtime directory.
-  Should we send those artifacts to `build/libs` or `build/runtime` under Gradle?
-* `jdk5Stubs` seems to refer to an empty collection. We could get rid of it and simplify the build script.
-
-=== Module-loader
-
-It needed a special configuration to pick up the `car` file from `language`.
-
-=== Tool-provider
-
-It needed a special configuration to pick up the `car` file from `language`.
-
-There is a `sourceSets` block in the build to find the correct resources files.
-If those files could simply be moved to the `src/main/resources` folder the whole block can be eliminated.
-
-Note that unlike the Ant build, the `*.utf8properties` are included in the block as the `processResources` task
-knows how to take care of them.
-
-.TODO
-* Do we need to set the compiler flag `-XDignore.symbol.file` ?
-
-=== Java-main
-
-.TODO
-* Do we need to set the compiler flag `-XDignore.symbol.file` ?
 
 == Custom build code in buildSrc
 

--- a/gradle-migration.adoc
+++ b/gradle-migration.adoc
@@ -9,6 +9,7 @@ Ant & Gradle builds.
 * bundle-proxy
 * Tests are disabled globally.
 * Jigsaw support via `-Pjigsaw=1`
+* Documentation building
 
 == Subprojects
 

--- a/gradle/java-for-modules.gradle
+++ b/gradle/java-for-modules.gradle
@@ -207,10 +207,3 @@ if(ext.properties.containsKey('ceylonTestDisabled') && ext.ceylonTestDisabled ==
     testClasses.enabled = false
     compileTestJava.enabled = false
 }
-
-afterEvaluate {
-    tasks.withType(JavaCompile) { t ->
-        t.options.compilerArgs ['-Xlint:-options']
-        t.options.encoding = 'UTF-8'
-    }
-}

--- a/gradle/java-for-modules.gradle
+++ b/gradle/java-for-modules.gradle
@@ -202,7 +202,7 @@ clean {
 }
 
 // TODO: Fix tests
-if(ext.properties.containsKey('ceylonTestDisabled')) {
+if(ext.properties.containsKey('ceylonTestDisabled') && ext.ceylonTestDisabled == true) {
     test.enabled = false
     testClasses.enabled = false
     compileTestJava.enabled = false

--- a/language/language.gradle
+++ b/language/language.gradle
@@ -28,7 +28,7 @@ task invokeAntBuild( type : GradleBuild ) {
     ]
 
     // TODO: There are too many of these manual dependencies being listed... feels like duct-tape and string.
-    dependsOn ':compiler-java:assemble', ':compiler-java:publishJvmCompilerJars', ':runtime:setupRepo'
+    dependsOn ':compiler-java:assemble', ':compiler-java:publishJvmCompilerJars', ':runtime-externals:setupRepo'
 }
 
 assemble.dependsOn invokeAntBuild

--- a/language/language.gradle
+++ b/language/language.gradle
@@ -28,7 +28,7 @@ task invokeAntBuild( type : GradleBuild ) {
     ]
 
     // TODO: There are too many of these manual dependencies being listed... feels like duct-tape and string.
-    dependsOn ':compiler-java:assemble', ':compiler-java:publishJvmCompilerJars', ':runtime-externals:setupRepo'
+    dependsOn ':compiler-java:assemble', ':ant-plugin:publishInternal', ':ceylon-bootstrap:publishInternal',':runtime-externals:setupRepo'
 }
 
 assemble.dependsOn invokeAntBuild

--- a/runtime-externals/runtime-externals.gradle
+++ b/runtime-externals/runtime-externals.gradle
@@ -1,0 +1,50 @@
+apply plugin : LifecycleBasePlugin
+apply from : 'task-generator.gradle'
+
+ext {
+    externalDepsDestinationDir = file("${buildDir}/ceylon-externals")
+    externalsSourceDir = file("${project(':runtime').projectDir}/dist/repo")
+}
+
+task sha1Externals( type : Checksum ) {
+    group "Build"
+    description "Create SHA1 checksum for external dependencies"
+}
+
+task addModuleDescriptorsForExternalDependencies {
+    group "Build"
+    description "Lifecycle task for handling external dependencies"
+    dependsOn sha1Externals
+}
+
+task setupRepo( type : Copy ) {
+    group "Setup"
+    description "Setup the basic structure of the dist folder by copying the template folder"
+    dependsOn addModuleDescriptorsForExternalDependencies
+    into repoDir
+    from externalDepsDestinationDir
+    exclude 'classes'
+}
+
+task cleanRepo {
+    dependsOn cleanSetupRepo
+}
+
+assemble {
+    dependsOn addModuleDescriptorsForExternalDependencies
+}
+
+clean {
+    dependsOn cleanRepo
+}
+
+createCeylonTasksFor externalsSourceDir,
+    externalDepsDestinationDir,
+    sha1Externals,
+    addModuleDescriptorsForExternalDependencies,
+    fileTree(externalsSourceDir) {
+        include '**/*.jar'
+        exclude "**/ceylon/**" // <-- we do this as we have moved ceylon modules to their own subprojects.
+    }
+
+

--- a/runtime-externals/task-generator.gradle
+++ b/runtime-externals/task-generator.gradle
@@ -1,0 +1,67 @@
+apply plugin : CeylonBuildOsgiPlugin
+
+ext.createTasksFor = { File baseFile,File jarFile, File depsDestination, Task checksum, Task parentLifecycleTask ->
+    String taskNamePostfix = jarFile.name[0..-5]
+    String relativePath = CeylonBuildUtil.relativeTo(jarFile.parentFile.absoluteFile,baseFile)
+    File depsFullDestination = project.file("${depsDestination}/${relativePath}")
+
+    Task fakeClasses = tasks.getByName('fakeClassesDirForExternalDependencies')
+
+    Task moduleTask = tasks.create( "addModuleXml_${taskNamePostfix}", CeylonBuildModuleXml) {
+        group "Build"
+        description "Prepare module.xml for ${taskNamePostfix}"
+        sourceModule new File(jarFile.parentFile,'module.xml')
+        destinationDir depsFullDestination
+    }
+
+    Task osgiJar = tasks.create( "addOsgiManifest_${taskNamePostfix}", Jar ) {
+        group "Build"
+        description "Add OSGI data to manifest for ${taskNamePostfix}"
+        archiveName jarFile.name
+        destinationDir  depsFullDestination
+        dependsOn moduleTask
+        dependsOn fakeClasses
+        setAsOsgiExternalArchive()
+
+        from zipTree(jarFile), {
+            exclude 'META-INF/MANIFEST.MF'
+        }
+
+        manifest {
+            classesDir fakeClasses.outputDir
+        }
+
+        ceylon {
+            seedFrom jarFile
+            moduleLocation {moduleTask.destinationFile}
+            forceNewOsgiManifest relativePath.matches(~/.+[\\\/](logmanager|slf4j)[\\\/].+/)
+        }
+
+        from moduleTask, {
+            into "META-INF/jbossmodules/${relativePath}"
+        }
+
+        doFirst { mkdir manifest.classesDir }
+    }
+
+    checksum.archive osgiJar
+    checksum.dependsOn osgiJar
+    parentLifecycleTask.dependsOn osgiJar, moduleTask
+
+}
+
+ext.createCeylonTasksFor = { File baseFile, File depsDestination, Task checksum, Task parentLifecycleTask, FileCollection jars ->
+    jars.files.each {
+        createTasksFor baseFile, it, depsDestination, checksum, parentLifecycleTask
+    }
+}
+
+task fakeClassesDirForExternalDependencies  {
+    ext {
+        outputDir = file("${buildDir}/classes/fake")
+    }
+    outputs.dir outputDir
+    doFirst {
+        mkdir outputDir
+    }
+}

--- a/runtime/runtime.gradle
+++ b/runtime/runtime.gradle
@@ -9,11 +9,6 @@ ext {
 
 apply from : "${rootProject.projectDir}/gradle/java-for-modules.gradle"
 
-
-ext {
-    externalDepsDestinationDir = "${buildDir}/ceylon-externals"
-}
-
 dependencies {
     compile project(':common')
     compile project(':cli')
@@ -50,87 +45,8 @@ task pluginFiles( type : Copy ) {
     filter ReplaceTokens, tokens : [ 'ceylon-version' : version ]
 }
 
-task addModuleDescriptorsForExternalDependencies {
-    group "Build"
-    description "Lifecycle task for handling external dependencies"
-}
-
-task fakeClasseDirForExternalDependencies  {
-    ext {
-        outputDir = file("${externalDepsDestinationDir}/classes")
-    }
-    outputs.dir outputDir
-    doFirst {
-        mkdir outputDir
-    }
-}
-
-task sha1Externals( type : Checksum ) {
-    group "Build"
-    description "Create SHA1 checksum for external dependencies"
-}
-
-// Add tasks for each of the external JARs
-(fileTree('dist/repo') {
-    include '**/*.jar'
-    exclude "**/ceylon/**" // <-- we do this as we have moved ceylon modules to their own subprojects.
-}).files.each { jarFile ->
-    String taskNamePostfix = jarFile.name[0..-5]
-    String relativePath = CeylonBuildUtil.relativeTo(jarFile.parentFile.absoluteFile,file('dist/repo'))
-
-    Task moduleTask = tasks.create( "addModuleXml_${taskNamePostfix}", CeylonBuildModuleXml) {
-        group "Build"
-        description "Prepare module.xml for ${taskNamePostfix}"
-        sourceModule new File(jarFile.parentFile,'module.xml')
-        destinationDir "${externalDepsDestinationDir}/${relativePath}"
-    }
-
-    Task osgiJar = tasks.create( "addOsgiManifest_${taskNamePostfix}", Jar ) {
-        group "Build"
-        description "Add OSGI data to manifest for ${taskNamePostfix}"
-        archiveName jarFile.name
-        destinationDir  file("${externalDepsDestinationDir}/${relativePath}")
-        dependsOn moduleTask
-        dependsOn fakeClasseDirForExternalDependencies
-        setAsOsgiExternalArchive()
-
-        from zipTree(jarFile), {
-            exclude 'META-INF/MANIFEST.MF'
-        }
-
-        manifest {
-            classesDir fakeClasseDirForExternalDependencies.outputDir
-        }
-
-        ceylon {
-            seedFrom jarFile
-            moduleLocation {moduleTask.destinationFile}
-            forceNewOsgiManifest relativePath.matches(~/.+[\\\/](logmanager|slf4j)[\\\/].+/)
-        }
-
-        from moduleTask, {
-            into "META-INF/jbossmodules/${relativePath}"
-        }
-
-        doFirst { mkdir manifest.classesDir }
-    }
-
-    sha1Externals.archive osgiJar
-    sha1Externals.dependsOn osgiJar
-    addModuleDescriptorsForExternalDependencies.dependsOn osgiJar, moduleTask, sha1Externals
-}
-
 assemble {
-    dependsOn pluginFiles, addModuleDescriptorsForExternalDependencies
-}
-
-task setupRepo( type : Copy ) {
-    group "Setup"
-    description "Setup the basic structure of the dist folder by copying the template folder"
-    dependsOn addModuleDescriptorsForExternalDependencies
-    into repoDir
-    from externalDepsDestinationDir
-    exclude 'classes'
+    dependsOn pluginFiles
 }
 
 ['common','cmr','language','tool-provider','java-main'].each {

--- a/sdk-build/ant.gradle
+++ b/sdk-build/ant.gradle
@@ -1,0 +1,22 @@
+//ant.properties.'ceylon.dist.dir' = project.properties.ceylonDistDir
+//ant.properties.'ceylon.repo.dir' = project.properties.ceylonRepoDir
+// ceylon.main.dir
+//     <property name="ceylon.executable" value="${ceylon.main.dir}/dist/dist/bin/ceylon"/>
+//             <pathelement location="${ceylon.main.dir}/lib/ant-contrib-1.0b3.jar"/>
+//'''    <taskdef resource="taskdef.properties">
+//        <classpath>
+//            <pathelement path="${ceylon.main.dir}/lib/org.osgi.impl.bundle.repoindex.ant-2.1.2.jar" />
+//        </classpath>
+//    </taskdef>
+//
+//    <taskdef resource="aQute/bnd/ant/taskdef.properties"
+//          classpath="${ceylon.main.dir}/lib/biz.aQute.bnd-2.3.0.jar"/>
+//
+//    <taskdef name="bindex" classname="org.osgi.impl.bundle.bindex.ant.BindexTask"
+//          classpath="${ceylon.main.dir}/lib/org.osgi.impl.bundle.bindex-2.2.0.jar"/>
+//'''
+
+ant.properties.'build.dir' = project.properties.ceylonBuildDir
+ant.properties.'ceylon.main.dir' = project.properties.ceylonMainDir
+ant.properties.'ceylon.ant.lib' = project.properties.ceylonAntJar
+ant.importBuild("${project.properties.antProjectDir}/build.xml") { "ant${it.capitalize()}".toString() }

--- a/sdk-build/build.gradle
+++ b/sdk-build/build.gradle
@@ -1,0 +1,114 @@
+plugins {
+    id 'de.qaware.seu.as.code.git' version '2.2.0'
+}
+
+apply plugin : LifecycleBasePlugin
+
+configurations {
+    antBuildEnv
+}
+
+repositories {
+    // TODO: Still refering back to lib directory, because the lib cannot be foudn on the 'net.
+    flatDir {
+        dirs "${rootProject.projectDir}/lib"
+    }
+}
+
+dependencies {
+    antBuildEnv antContribDep
+    antBuildEnv antlrDep
+    antBuildEnv osgiBndDep
+    antBuildEnv osgiBndAntDep
+    antBuildEnv osgiBindexDep
+}
+
+ext {
+    githubOrgOrUser = project.properties.ceylonGitHubOrgOrUser ?: 'ceylon'
+    githubRepoName = 'ceylon-sdk'
+    localRepoFolder   = file("${buildDir}/${githubRepoName}")
+    localRepoBuildDir = file("${buildDir}/build-${githubRepoName}")
+    localRepoMainDir  = file("${localRepoBuildDir}/main")
+    localRepoExists   = file("${localRepoFolder}/.git").exists()
+    localRepoDistDir  = file("${localRepoMainDir}/dist/dist")
+}
+
+git {
+    sdk {
+        url "https://github.com/${githubOrgOrUser}/${githubRepoName}.git"
+        directory localRepoFolder
+        branch 'HEAD'
+//        username gitUsername
+//        password gitPassword
+        singleBranch false
+    }
+}
+
+task setup {
+    group "Git Lifecycle"
+    description "Clones a new repo for ${githubRepoName}"
+    dependsOn 'gitCloneSdk'
+}
+
+task update {
+    group "Git Lifecycle"
+    description "Updated ${githubRepoName} to latest version"
+    dependsOn localRepoExists ? 'gitPullSdk' : 'gitCloneSdk'
+}
+
+task status {
+    group "Git Lifecycle"
+    description "Shows git status for ${githubRepoName}"
+    dependsOn 'gitStatusSdk'
+    enabled = localRepoExists
+}
+
+
+// TODO: task setup-admins
+
+clean {
+    delete = []
+    delete localRepoBuildDir
+}
+
+task createAntBuildEnvironment( type : Copy ) {
+    into localRepoMainDir
+
+    from configurations.antBuildEnv, {
+        into 'lib'
+    }
+
+    from distDir, {
+        into 'dist/dist'
+    }
+
+    dependsOn ':dist:publishInternal'
+}
+
+task invokeAntBuild( type : GradleBuild ) {
+    dir = localRepoFolder
+    buildFile = file('ant.gradle')
+    tasks = ['antPublish']
+    startParameter.projectProperties+= [
+        ceylonBuildDir : localRepoBuildDir,
+        ceylonMainDir  : localRepoMainDir,
+        ceylonAntJar   : "${repoLibDir}/ceylon-ant.jar",
+        antProjectDir  : localRepoFolder
+    ]
+
+    mustRunAfter update, setup
+
+    if(!localRepoExists) {
+        dependsOn setup
+    }
+
+    dependsOn createAntBuildEnvironment
+}
+
+build {
+    dependsOn invokeAntBuild
+}
+
+task publishInternal {
+    dependsOn build
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,9 @@ project(':dist').buildFileName = 'dist.gradle'
 include 'runtime'
 project(':runtime').buildFileName = 'runtime.gradle'
 
+include 'runtime-externals'
+project(':runtime-externals').buildFileName = 'runtime-externals.gradle'
+
 include 'common'
 project(':common').buildFileName = 'common.gradle'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,3 +58,4 @@ project(':tool-provider').buildFileName = 'toolprovider.gradle'
 include 'typechecker'
 project(':typechecker').buildFileName = 'typechecker.gradle'
 
+include 'sdk-build'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,24 +1,11 @@
+include 'ant-plugin'
+project(':ant-plugin').buildFileName = 'antplugin.gradle'
 
-include 'dist'
-project(':dist').buildFileName = 'dist.gradle'
-
-include 'runtime'
-project(':runtime').buildFileName = 'runtime.gradle'
-
-include 'runtime-externals'
-project(':runtime-externals').buildFileName = 'runtime-externals.gradle'
-
-include 'common'
-project(':common').buildFileName = 'common.gradle'
+include 'ceylon-bootstrap'
+project(':ceylon-bootstrap').buildFileName = 'bootstrap.gradle'
 
 include 'cli'
 project(':cli').buildFileName = 'cli.gradle'
-
-include 'model'
-project(':model').buildFileName = 'model.gradle'
-
-include 'langtools-classfile'
-project(':langtools-classfile').buildFileName = 'langtools.gradle'
 
 include 'cmr'
 project(':cmr').buildFileName = 'cmr.gradle'
@@ -32,23 +19,42 @@ project(':cmr-webdav').buildFileName = 'webdav.gradle'
 include 'cmr-js'
 project(':cmr-js').buildFileName = 'cmrjs.gradle'
 
-include 'typechecker'
-project(':typechecker').buildFileName = 'typechecker.gradle'
+include 'common'
+project(':common').buildFileName = 'common.gradle'
 
 include 'compiler-java'
 project(':compiler-java').buildFileName = 'compilerjava.gradle'
 
+include 'compiler-js'
+project(':compiler-js').buildFileName = 'compilerjs.gradle'
+
+include 'dist'
+project(':dist').buildFileName = 'dist.gradle'
+
+include 'java-main'
+project(':java-main').buildFileName = 'javamain.gradle'
+
+include 'langtools-classfile'
+project(':langtools-classfile').buildFileName = 'langtools.gradle'
+
 include 'language'
 project(':language').buildFileName = 'language.gradle'
 
-include 'compiler-js'
-project(':compiler-js').buildFileName = 'compilerjs.gradle'
+include 'model'
+project(':model').buildFileName = 'model.gradle'
 
 include 'module-loader'
 project(':module-loader').buildFileName = 'moduleloader.gradle'
 
+include 'runtime'
+project(':runtime').buildFileName = 'runtime.gradle'
+
+include 'runtime-externals'
+project(':runtime-externals').buildFileName = 'runtime-externals.gradle'
+
 include 'tool-provider'
 project(':tool-provider').buildFileName = 'toolprovider.gradle'
 
-include 'java-main'
-project(':java-main').buildFileName = 'javamain.gradle'
+include 'typechecker'
+project(':typechecker').buildFileName = 'typechecker.gradle'
+


### PR DESCRIPTION
This is a smaller changeset mostly focused on fixing issues from #6394.

_Main features of this PR:_
- The `ceylon-ant.jar` and `ceylon-bootstrap.jar` artifacts are built as separate subprojects. THe source code still resides within `compiler-java`, keepint the build compatible with Ant, but the build areas for `compiler-java` and the other two artifacts are now separated in Gradle, leading to simpler & cleaner builds.
- SDK build integrated
  - Top-level tasks `sdk`, `clean-sdk`, `clean-all`
  - Local tasks `setup`, `update`, `status` 
- Fixed the `ceylonTestDisabled = false` issues
- Fixed duplicates in the `common` test runs which appeared in Gradle builds, but not Ant builds.
- Added a top-level `dependencies.gradle` file for defining dependencies in a global manner, which can then be re-used in subprojects as appropriate.

_Outstanding:_
- Do we need to make equivalant top-level tasks `setup-all`, `update-all`, `status` ?
- `proxy-bundle`, `ide`, (A good list exists within `dist.gradle`).
- A number of TODOs are still listed in gradle-migration.adoc.
- Tests are still disabled in most subprojects.
- `sdk-build` is till using `org.osgi.imple.bundle.bindex-2.2.0` from the `lib` folder as it is not available in either `mavenCentral` or `jcenter`.

_Known issues:_
- For `sdk` build the `update` tasks will just do a `git pull`, rather than `git pull --rebase`. There is an issue open with the specific plugin to add the `--rebase` functionality.
