### PR TITLE
fix memory leak in Iterable.summarize and package.set

### DIFF
--- a/language/src/ceylon/language/Set.ceylon
+++ b/language/src/ceylon/language/Set.ceylon
@@ -196,8 +196,14 @@ shared Set<Element> set<Element>(
     Element choosing(Element earlier, Element later) 
             => earlier)
         given Element satisfies Object
-        => object extends Object() 
-        satisfies Set<Element&Object> {
+        => IterableSet(stream, choosing);
+
+class IterableSet<Element>(
+    {Element*} stream,
+    Element choosing(Element earlier, Element later))
+        extends Object()
+        satisfies Set<Element>
+        given Element satisfies Object {
     
     value elements =
             stream.summarize(identity,
@@ -216,9 +222,7 @@ shared Set<Element> set<Element>(
     
     clone() => this;
     
-};
-
-
+}
 
 "An immutable [[Set]] with no elements."
 tagged("Collections")


### PR DESCRIPTION
In both cases, an anonymous class was capturing the Iterable holding the source data for the map/set. Making the Map & Set toplevel classes avoids the captures.

This seems straight forward to me, but opening a PR in case @gavinking disagrees.

The memory leak was originally discovered by @davidfestal and is exposed after about 18 iterations in the following test code:

``` ceylon
shared void run() {
    variable {Anything*} smallObjects = [];
    value bigSequence => [ for (i in 0:10M) i ];
    for (i in 0:1000) {
        print(i);

        // test toplevel set memory leak
        smallObjects = smallObjects.follow {
            set(bigSequence.take(1));
        };

        // test Iterable.summarize memory leak
        smallObjects = smallObjects.follow {
            bigSequence.take(1).summarize {
                grouping = identity;
                accumulating(Anything current, Integer element) => element;
            };
        };
    }
}
```
