### PR TITLE
make Array.copyTo and String.copyTo's destination param contravariant

### DIFF
--- a/language/runtime/ceylon/language/Array.java
+++ b/language/runtime/ceylon/language/Array.java
@@ -1937,51 +1937,69 @@ public final class Array<Element>
     }
     
     @Ignore
-    public long copyTo$sourcePosition(Array<Element> destination){
+    public long copyTo$sourcePosition(Array<? super Element> destination){
         return 0L;
     }
 
     @Ignore
-    public long copyTo$destinationPosition(Array<Element> destination, 
+    public long copyTo$destinationPosition(Array<? super Element> destination, 
             long sourcePosition){
         return 0L;
     }
 
     @Ignore
-    public long copyTo$length(Array<Element> destination, 
+    public long copyTo$length(Array<? super Element> destination, 
             long sourcePosition, long destinationPosition){
         return Math.min(size-sourcePosition,
                 destination.getSize()-destinationPosition);
     }
 
     @Ignore
-    public void copyTo(Array<Element> destination){
+    public void copyTo(Array<? super Element> destination){
         copyTo(destination, 0L, 0L);
     }
 
     @Ignore
-    public void copyTo(Array<Element> destination, long sourcePosition) {
+    public void copyTo(Array<? super Element> destination, long sourcePosition) {
         copyTo(destination, sourcePosition, 0L);
     }
 
     @Ignore
-    public void copyTo(Array<Element> destination, 
+    public void copyTo(Array<? super Element> destination, 
             long sourcePosition, long destinationPosition) {
         copyTo(destination, sourcePosition, destinationPosition, 
                 copyTo$length(destination, sourcePosition, destinationPosition));
     }
 
-    public void copyTo(@Name("destination") Array<Element> destination, 
+    public void copyTo(@Name("destination")
+                       @TypeInfo("ceylon.language::Array<in Element>") Array<? super Element> destination,
                        @Name("sourcePosition") @Defaulted long sourcePosition, 
                        @Name("destinationPosition") @Defaulted long destinationPosition, 
                        @Name("length") @Defaulted long length) {
         if (length>0) {
             try {
-                arraycopy(array, 
-                        Util.toInt(sourcePosition), 
-                        destination.array, 
-                        Util.toInt(destinationPosition), 
-                        Util.toInt(length));
+                if (elementType == destination.elementType) {
+                    arraycopy(array,
+                            Util.toInt(sourcePosition),
+                            destination.array,
+                            Util.toInt(destinationPosition),
+                            Util.toInt(length));
+                }
+                else {
+                    // unbox as necessary
+                    int srcIndex = Util.toInt(sourcePosition);
+                    int dstIndex = Util.toInt(destinationPosition);
+                    int len = Util.toInt(length);
+
+                    if (srcIndex < 0 || dstIndex < 0
+                            || srcIndex + len > getSize()
+                            || dstIndex + len > destination.getSize()) {
+                        throw new AssertionError("Index out of bounds");
+                    }
+                    while (len-- > 0) {
+                        destination.set(dstIndex++, getFromFirst(srcIndex++));
+                    }
+                }
             }
             catch (IndexOutOfBoundsException iob) {
                 throw new AssertionError(iob.getMessage());

--- a/language/runtime/ceylon/language/Array.java
+++ b/language/runtime/ceylon/language/Array.java
@@ -1986,18 +1986,23 @@ public final class Array<Element>
                             Util.toInt(length));
                 }
                 else {
-                    // unbox as necessary
+                    // Box. Given that the special types String, Integer, etc. are all
+                    // final, widening will always be to a type like Object or Number<>
+                    // for which the value will be stored in boxed form. Arrays that
+                    // hold subtypes of the special types will be empty. We can
+                    // therefore write the values obtained by src.getFromFirst() directly
+                    // to the destination array (i.e. without using destination.set())
+                    java.lang.Object[] dst = (java.lang.Object[]) destination.array;
                     int srcIndex = Util.toInt(sourcePosition);
                     int dstIndex = Util.toInt(destinationPosition);
                     int len = Util.toInt(length);
-
                     if (srcIndex < 0 || dstIndex < 0
                             || srcIndex + len > getSize()
                             || dstIndex + len > destination.getSize()) {
                         throw new AssertionError("Index out of bounds");
                     }
                     while (len-- > 0) {
-                        destination.set(dstIndex++, getFromFirst(srcIndex++));
+                        dst[dstIndex++] = getFromFirst(srcIndex++);
                     }
                 }
             }

--- a/language/runtime/ceylon/language/String.java
+++ b/language/runtime/ceylon/language/String.java
@@ -2901,35 +2901,35 @@ public final class String
     }
     
     @Ignore
-    public long copyTo$sourcePosition(Array<Character> destination){
+    public long copyTo$sourcePosition(Array<? super Character> destination){
         return 0;
     }
 
     @Ignore
-    public long copyTo$destinationPosition(Array<Character> destination, 
+    public long copyTo$destinationPosition(Array<? super Character> destination, 
             long sourcePosition){
         return 0;
     }
 
     @Ignore
-    public long copyTo$length(Array<Character> destination, 
+    public long copyTo$length(Array<? super Character> destination, 
             long sourcePosition, long destinationPosition){
         return Math.min(value.length()-sourcePosition,
                 destination.getSize()-destinationPosition);
     }
 
     @Ignore
-    public static void copyTo(java.lang.String value, Array<Character> destination){
+    public static void copyTo(java.lang.String value, Array<? super Character> destination){
         copyTo(value, destination, 0, 0);
     }
 
     @Ignore
-    public static void copyTo(java.lang.String value, Array<Character> destination, long sourcePosition){
+    public static void copyTo(java.lang.String value, Array<? super Character> destination, long sourcePosition){
         copyTo(value, destination, sourcePosition, 0);
     }
 
     @Ignore
-    public static void copyTo(java.lang.String value, Array<Character> destination, 
+    public static void copyTo(java.lang.String value, Array<? super Character> destination, 
             long sourcePosition, long destinationPosition){
         copyTo(value, destination, 
                 sourcePosition, destinationPosition, 
@@ -2938,17 +2938,17 @@ public final class String
     }
 
     @Ignore
-    public void copyTo(Array<Character> destination){
+    public void copyTo(Array<? super Character> destination){
         copyTo(value, destination, 0, 0);
     }
 
     @Ignore
-    public void copyTo(Array<Character> destination, long sourcePosition){
+    public void copyTo(Array<? super Character> destination, long sourcePosition){
         copyTo(value, destination, sourcePosition, 0);
     }
 
     @Ignore
-    public void copyTo(Array<Character> destination, 
+    public void copyTo(Array<? super Character> destination, 
             long sourcePosition, long destinationPosition){
         copyTo(value, destination, 
                 sourcePosition, destinationPosition, 
@@ -2957,21 +2957,33 @@ public final class String
 
     @Ignore
     public static void copyTo(java.lang.String value,
-            Array<Character> destination, 
+            Array<? super Character> destination, 
             long sourcePosition, 
             long destinationPosition, 
             long length){
         int count = 0;
         int src = Util.toInt(sourcePosition);
         int dest = Util.toInt(destinationPosition);
-        int[] array = (int[]) destination.toArray();
+
         try {
-            for (int index = value.offsetByCodePoints(0,src); 
-                    count<length;) {
-                int codePoint = value.codePointAt(index);
-                array[count+dest] = codePoint;
-                index += java.lang.Character.charCount(codePoint);
-                count++;
+            if (destination.toArray() instanceof int[]) {
+                int[] array = (int[]) destination.toArray();
+                for (int index = value.offsetByCodePoints(0,src); 
+                        count<length;) {
+                    int codePoint = value.codePointAt(index);
+                    array[count+dest] = codePoint;
+                    index += java.lang.Character.charCount(codePoint);
+                    count++;
+                }
+            } else {
+                java.lang.Object[] array = (java.lang.Object[]) destination.toArray();
+                for (int index = value.offsetByCodePoints(0,src); 
+                        count<length;) {
+                    int codePoint = value.codePointAt(index);
+                    array[count+dest] = Character.instance(codePoint);
+                    index += java.lang.Character.charCount(codePoint);
+                    count++;
+                }
             }
         }
         catch (IndexOutOfBoundsException iob) {
@@ -2979,9 +2991,10 @@ public final class String
         }
     }
 
-    public void copyTo(@Name("destination") Array<Character> destination, 
-                       @Name("sourcePosition") @Defaulted long sourcePosition, 
-                       @Name("destinationPosition") @Defaulted long destinationPosition, 
+    public void copyTo(@TypeInfo("ceylon.language::Array<in ceylon.language::Character>")
+                       @Name("destination") Array<? super Character> destination,
+                       @Name("sourcePosition") @Defaulted long sourcePosition,
+                       @Name("destinationPosition") @Defaulted long destinationPosition,
                        @Name("length") @Defaulted long length){
         copyTo(value, destination, sourcePosition, destinationPosition, length);
     }

--- a/language/src/ceylon/language/Array.ceylon
+++ b/language/src/ceylon/language/Array.ceylon
@@ -121,7 +121,7 @@ shared final serializable native class Array<Element>
     void copyTo(
         "The array into which to copy the elements, which 
          may be this array."
-        Array<Element> destination,
+        Array<in Element> destination,
         "The index of the first element in this array to 
          copy."
         Integer sourcePosition = 0,

--- a/language/src/ceylon/language/String.ceylon
+++ b/language/src/ceylon/language/String.ceylon
@@ -751,7 +751,7 @@ shared native final class String(characters)
     shared native 
     void copyTo(
         "The array into which to copy the elements."
-        Array<Character> destination,
+        Array<in Character> destination,
         "The index of the first element in this array to 
          copy."
         Integer sourcePosition = 0,

--- a/language/test/jvm/arrays.ceylon
+++ b/language/test/jvm/arrays.ceylon
@@ -1,0 +1,40 @@
+import java.lang {
+    JLong = Long
+}
+import check {
+    check
+}
+
+shared void testArrays() {
+    // contravariant Array.copyTo() types
+    value ceylonStringArray = Array<String>((0..1).map(Object.string));
+    value ceylonIntegerArray = Array<Integer>(0..3);
+    value javaLongArray = Array<JLong>((0..5).map((Integer i) => JLong.valueOf(i)));
+    value objectArray = Array<Object>.ofSize(6, finished);
+    ceylonStringArray.copyTo(objectArray);
+    ceylonIntegerArray.copyTo(objectArray, 2, 2);
+    javaLongArray.copyTo(objectArray, 4, 4);
+    check(objectArray[0] is String, "box to c.l::String");
+    check(objectArray[3] is Integer, "box to c.l::Integer");
+    check(objectArray[4] is JLong, "box to j.l.Long");
+    check(objectArray == Array { "0", "1", 2, 3, JLong.valueOf(4), JLong.valueOf(5) },
+            "correct values");
+
+    // contravariant Array.copyTo() index validation
+    try {
+        ceylonStringArray.copyTo(objectArray, -1);
+        check(false, "copyTo negative source index");
+    } catch (AssertionError e) {}
+    try {
+        ceylonStringArray.copyTo(objectArray, 0, -1);
+        check(false, "copyTo negative destination index");
+    } catch (AssertionError e) {}
+    try {
+        ceylonStringArray.copyTo(objectArray, 1, 0, 2);
+        check(false, "failed check: copyTo source length");
+    } catch (AssertionError e) {}
+    try {
+        ceylonStringArray.copyTo(objectArray, 0, 5, 2);
+        check(false, "failed check: copyTo destination length");
+    } catch (AssertionError e) {}
+}

--- a/language/test/jvm/tests.ceylon
+++ b/language/test/jvm/tests.ceylon
@@ -1,5 +1,7 @@
 shared void run() {
     bug365();
     bug200();
+    print("JVM Arrays");
+    testArrays();
 }
 shared void test() { run(); }

--- a/language/test/strings.ceylon
+++ b/language/test/strings.ceylon
@@ -583,6 +583,10 @@ shared void strings() {
     value charr=Array.ofSize(3,'x');
     "abc".copyTo(charr);
     check(charr==Array{'a','b','c'}, "String.copyTo");
+    value objectArray=Array<Object>.ofSize(3, 0);
+    "abc".copyTo(objectArray);
+    check(objectArray==Array{'a','b','c'}, "String.copyTo contravariant 1");
+    check(objectArray==Array<Object>{'a','b','c'}, "String.copyTo contravariant 2");
     /*check("abc".lookup(2).key, "String.lookup 1");
     check("abc".lookup(2).item exists, "String.lookup 2");
     check(!"abc".lookup(10).key, "String.lookup 3");


### PR DESCRIPTION
Support `fooArray.copyTo(objectArray)` and `"abc".copyTo(objectArray)`.

This works, but it wouldn't hurt for someone to make sure I handled the Java stuff correctly.
