### PR TITLE
adjust parseFloat algorithm, perform rounding

### DIFF
--- a/language/src/ceylon/language/formatFloat.ceylon
+++ b/language/src/ceylon/language/formatFloat.ceylon
@@ -16,7 +16,7 @@ import java.lang {
  respectively, so that by default the string representation
  always contains a decimal point, and never contains more 
  than nine decimal places. The decimal representation is 
- truncated so that the number of decimal places never 
+ rounded so that the number of decimal places never
  exceeds the specified maximum.
  
  For example:
@@ -27,6 +27,7 @@ import java.lang {
  - `formatFloat(1234.0,0)` is `\"1234\"`
  - `formatFloat(1234.1234,6)` is `\"1234.123400\"`
  - `formatFloat(1234.1234,0,2)` is `\"1234.12\"`
+ - `formatFloat(1234.123456,0,5)` is `\"1234.12346\"`
  - `formatFloat(0.0001,2,2)` is `\"0.00\"`
  - `formatFloat(0.0001,0,2)` is `\"0\"`
  

--- a/language/src/ceylon/language/formatFloat.ceylon
+++ b/language/src/ceylon/language/formatFloat.ceylon
@@ -159,15 +159,30 @@ Integer exponent(variable Float f)
         then l10.wholePart.integer
         else l10.wholePart.integer - 1;
 
-Float scaleByPowerOfTen(Float float, Integer power) {
-    value scale =
-            let (magnitude = power.magnitude) 
-            if (magnitude <= 15)
-                then (10^magnitude).nearestFloat     //fast
-                else 10.0.powerOfInteger(magnitude); //slow
-    return if (power < 0) 
-            then float / scale 
-            else float * scale;
+Float scaleByPowerOfTen(Float float, variable Integer power) {
+    function doScale(Float float, Integer power) {
+        value scale =
+                let (magnitude = power.magnitude)
+                if (magnitude <= 15)
+                    then (10^magnitude).nearestFloat     //fast
+                    else 10.0.powerOfInteger(magnitude); //slow
+        return if (power < 0)
+                then float / scale
+                else float * scale;
+    }
+    // don't attempt to create a float larger than 1.0e308.
+    variable value result = float;
+    while (power > 0) {
+        value amount = smallest(308, power);
+        result = doScale(result, amount);
+        power -= amount;
+    }
+    while (power < 0) {
+        value amount = largest(-308, power);
+        result = doScale(result, amount);
+        power -= amount;
+    }
+    return result;
 }
 
 Float twoFiftyTwo = (2^52).float;

--- a/language/src/ceylon/language/formatFloat.ceylon
+++ b/language/src/ceylon/language/formatFloat.ceylon
@@ -88,14 +88,15 @@ shared String formatFloat(
         14 - exponent(magnitude);
     };
 
-    "The float, but with 0 to ~15 fractional digits shifted to the whole part"
+    "The float, but with all meaningful digits shifted to the
+     first ~15 positions of the whole part"
     value normalized = scaleByPowerOfTen(magnitude, decimalMoveRight);
 
-    "The usable digits: [[normalized]] as an [[integer]] after rounding"
+    "The usable digits: [[normalized]] as an [[Integer]] after rounding"
     variable value integer = halfEven(normalized).integer;
 
-    "The number of digits of [[integer]] that are
-     to the right of the decimal point in [[float]]"
+    "The number of digits of [[integer]] that are to the right of
+     the decimal point in [[float]]. May be negative."
     variable value fractionalPartDigits = decimalMoveRight;
 
     "Have any digits to the right of the '.' been emitted?"
@@ -130,7 +131,7 @@ shared String formatFloat(
     if (emittedFractional) {
         result.appendCharacter('.');
     }
-    if (integer.zero) {
+    if (integer == 0) {
         result.appendCharacter('0');
     }
     else {
@@ -145,7 +146,7 @@ shared String formatFloat(
             result.appendCharacter('0'.neighbour(digit));
         }
     }
-    if (float.negative) {
+    if (float < 0.0) {
         result.appendCharacter('-');
     }
     return(result.string.reversed);
@@ -154,7 +155,7 @@ shared String formatFloat(
 Integer exponent(variable Float f)
     =>  let (l10 = log10(f.magnitude))
         // now, compute the floor
-        if (l10.fractionalPart == 0.0 || l10.positive)
+        if (l10.fractionalPart == 0.0 || l10 > 0.0)
         then l10.wholePart.integer
         else l10.wholePart.integer - 1;
 

--- a/language/test/numbers.ceylon
+++ b/language/test/numbers.ceylon
@@ -1074,7 +1074,24 @@ void checkFormatFloat() {
     check(formatFloat(-1.234e+20)=="-123400000000000000000.0", "formatFloat(-1.234e+20)");
     check(formatFloat(-1.234e+25)=="-12340000000000000000000000.0", "formatFloat(-1.234e+25)");
     check(formatFloat(-1.234e+30)=="-1234000000000000000000000000000.0", "formatFloat(-1.234e+30)");
-    
+
+    value minFloatExpected = "0." + "0".repeat(323) + "494065645841247";
+    value minFloatActual = formatFloat(runtime.minFloatValue, 1, 400);
+    check(minFloatActual == minFloatExpected, "formatFloat(min)");
+    value maxFloatExpectedJS  = "179769313486231" + "0".repeat(294) + ".0";
+    value maxFloatExpectedJVM = "179769313486232" + "0".repeat(294) + ".0";
+    value maxFloatActual = formatFloat(runtime.maxFloatValue, 1, 400);
+    check(maxFloatActual in [maxFloatExpectedJS, maxFloatExpectedJVM], "formatFloat(max)");
+
+    check(formatFloat(0.99, 0, 0) == "1", "formatFloat halfeven rounding #1");
+    check(formatFloat(0.99, 1, 1) == "1.0", "formatFloat halfeven rounding #2");
+    check(formatFloat(1.1525, 1, 1) == "1.2", "formatFloat halfeven rounding #3");
+    check(formatFloat(1.1525, 3, 3) == "1.152", "formatFloat halfeven rounding #4");
+    check(formatFloat(-1.1525, 1, 1) == "-1.2", "formatFloat halfeven rounding #5");
+    check(formatFloat(-1.1525, 3, 3) == "-1.152", "formatFloat halfeven rounding #6");
+    check(formatFloat(1.111111111111115, 0, 100) == "1.11111111111112", "formatFloat halfeven rounding #7");
+    check(formatFloat(1.111111111111145, 0, 100) == "1.11111111111114", "formatFloat halfeven rounding #8");
+
     void checkNanComparisons<T>(T nan, T zero) 
             given T satisfies Comparable<T> {
         check(!nan == zero, "generic nan comparison");

--- a/language/test/numbers.ceylon
+++ b/language/test/numbers.ceylon
@@ -1042,7 +1042,7 @@ void checkFormatFloat() {
     check(formatFloat(1234.5678,4,4)=="1234.5678", "formatFloat(1234.5678,4,4)");
     check(formatFloat(5678.1234)=="5678.1234", "formatFloat(5678.1234)");
     check(formatFloat(5678.1234,4,4)=="5678.1234", "formatFloat(5678.1234,4,4)");
-    check(formatFloat(1234.5678,2,2)=="1234.56", "formatFloat(1234.5678,2,2)");
+    check(formatFloat(1234.5678,2,2)=="1234.57", "formatFloat(1234.5678,2,2)");
     check(formatFloat(5678.1234,3,3)=="5678.123", "formatFloat(5678.1234,3,3)");
     check(formatFloat(1234.1234)=="1234.1234", "formatFloat(1234.1234)");
     check(formatFloat(1234.1234,4,4)=="1234.1234", "formatFloat(1234.1234,4,4)");


### PR DESCRIPTION
A few items remain, but making this available for review by those who like to review such things. This PR addresses all outstanding issues as well as a few unreported bugs. It is also generally faster than the old code, and _much_ faster in some cases.

Todo:
- [ ] add more tests
- [ ] fix overflow in extreme cases like `1.0e-300`
- [ ] tweak docs for @lucaswerkmeister

See the commit message for more.

Fixes #6438 and #6436
