### PR TITLE
add Backend.Dart enum value

### DIFF
--- a/tool-provider/src/com/redhat/ceylon/compiler/java/runtime/tools/Backend.java
+++ b/tool-provider/src/com/redhat/ceylon/compiler/java/runtime/tools/Backend.java
@@ -1,5 +1,5 @@
 package com.redhat.ceylon.compiler.java.runtime.tools;
 
 public enum Backend {
-    JavaScript, Java;
+    JavaScript, Java, Dart;
 }


### PR DESCRIPTION
This is necessary in order to add Dart support to IntelliJ.

After looking through `git grep -l tools.Backend` and `git grep -l java.runtime.tools` in various repos, I don't see where this change can cause problems.

It is true that in `ceylon-ide-intellij` there is logic like "If not Java, it must be JavaScript", but that should be fine for the time being.
