### PR TITLE
account for characters before literal start pos for doclinks

### DIFF
--- a/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/LiteralVisitor.java
+++ b/typechecker/src/com/redhat/ceylon/compiler/typechecker/analyzer/LiteralVisitor.java
@@ -82,6 +82,10 @@ public class LiteralVisitor extends Visitor {
                 int charInLine = 
                         linesUpTo.length==0 ? 0 : 
                             linesUpTo[linesUpTo.length-1].length();
+                if (linesUpTo.length==1) {
+                    charInLine +=
+                            that.getToken().getCharPositionInLine();
+                }
                 token.setLine(line);
                 token.setCharPositionInLine(charInLine);
                 that.addDocLink(new Tree.DocLink(token));


### PR DESCRIPTION
I'm guessing this patch is correct, at least it seams to work.

For the first line of string literals, the starting character position for doclinks must take into account the starting character position of the string literal.

With `1.3.0`, introducing a doclink errors on the 1st & 2nd lines of the string literal results in `compile-js` and `compile-dart` output:

```
./source/ceylon/buffer/ByteBuffer.ceylon:16: warning: declaration is missing: 'ByteBufferX'
    "Creates a [[ByteBufferX]] x [[ByteBufferX]]initally backed by the given [[initialArray]].
             ^
./source/ceylon/buffer/ByteBuffer.ceylon:16: warning: declaration is missing: 'ByteBufferX'
    "Creates a [[ByteBufferX]] x [[ByteBufferX]]initally backed by the given [[initialArray]].
                               ^
./source/ceylon/buffer/ByteBuffer.ceylon:17: warning: declaration is missing: 'ByteBufferX'
     The capacity [[ByteBufferX]] of the new buffer will be the size of the array. The returned
                    ^
```

with this patch:

```
./source/ceylon/buffer/ByteBuffer.ceylon:16: warning: declaration is missing: 'ByteBufferX'
    "Creates a [[ByteBufferX]] x [[ByteBufferX]]initally backed by the given [[initialArray]].
                 ^
./source/ceylon/buffer/ByteBuffer.ceylon:16: warning: declaration is missing: 'ByteBufferX'
    "Creates a [[ByteBufferX]] x [[ByteBufferX]]initally backed by the given [[initialArray]].
                                   ^
./source/ceylon/buffer/ByteBuffer.ceylon:17: warning: declaration is missing: 'ByteBufferX'
     The capacity [[ByteBufferX]] of the new buffer will be the size of the array. The returned
                    ^
```
