### PR TITLE
call getDirectPackage(); don't search other modules

### DIFF
--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsModuleManager.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsModuleManager.java
@@ -66,7 +66,7 @@ public class JsModuleManager extends ModuleManager {
     @Override
     public com.redhat.ceylon.model.typechecker.model.Package createPackage(String pkgName, Module module) {
         if (module!=null && module == getModules().getDefaultModule()) {
-            com.redhat.ceylon.model.typechecker.model.Package pkg = module.getPackage(pkgName);
+            com.redhat.ceylon.model.typechecker.model.Package pkg = module.getDirectPackage(pkgName);
             if (pkg != null) {
                 return pkg;
             }


### PR DESCRIPTION
when attempting to create a package, it's not relevant if some other
module has a package with the desired name, so use getDirectPackage(),
not getPackage().
