### PR TITLE
don't memoize Module.signature with a null version

### DIFF
--- a/model/src/com/redhat/ceylon/model/typechecker/model/Module.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Module.java
@@ -440,9 +440,13 @@ public class Module
             if (isDefaultModule()) {
                 signature = getNameAsString();
             }
-            else {
+            else if (getVersion() != null) {
                 signature = getNameAsString() + 
                         "/" + getVersion();
+            }
+            else {
+                return getNameAsString() +
+                        "/null";
             }
         }
         return signature;


### PR DESCRIPTION
A Module is used in various ways before being assigned a version by the
typechecker. This patch avoids memoizing getSignature() with a null
version if equals(), hashCode(), getSignature(), etc. is called before
setVersion().

The known problem that this addresses is also fixed by https://github.com/ceylon/ceylon/pull/6517
