### PR TITLE
Add support for TypeScript enums

### DIFF
--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/GenerateJsVisitor.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/GenerateJsVisitor.java
@@ -1872,28 +1872,37 @@ public class GenerateJsVisitor extends Visitor {
             FunctionHelper.generateCallable(that, null, this);
         } else if (that.getStaticMethodReference() && d!=null) {
             if (d instanceof Value && ((Value)d).getTypeDeclaration() instanceof Constructor) {
-                //TODO this won't work anymore I think
-                boolean wrap = false;
-                if (that.getPrimary() instanceof Tree.QualifiedMemberOrTypeExpression) {
-                    Tree.QualifiedMemberOrTypeExpression prim = (Tree.QualifiedMemberOrTypeExpression)that.getPrimary();
-                    if (prim.getStaticMethodReference()) {
-                        wrap=true;
-                        out("function(_$){return _$");
-                    } else {
-                        prim.getPrimary().visit(this);
-                    }
-                    out(".");
+                Constructor cnst = (Constructor)((Value)d).getTypeDeclaration();
+                if (cnst.getTypescriptEnum() != null && cnst.getTypescriptEnum().matches("[0-9.-]+")) {
+                    out(cnst.getTypescriptEnum());
                 } else {
-                    if (d.getContainer() instanceof Declaration) {
-                        qualify(that.getPrimary(), (Declaration)d.getContainer());
-                    } else if (d.getContainer() instanceof Package) {
-                        out(names.moduleAlias(((Package)d.getContainer()).getModule()));
+                    //TODO this won't work anymore I think
+                    boolean wrap = false;
+                    if (that.getPrimary() instanceof Tree.QualifiedMemberOrTypeExpression) {
+                        Tree.QualifiedMemberOrTypeExpression prim = (Tree.QualifiedMemberOrTypeExpression)that.getPrimary();
+                        if (prim.getStaticMethodReference()) {
+                            wrap=true;
+                            out("function(_$){return _$");
+                        } else {
+                            prim.getPrimary().visit(this);
+                        }
+                        out(".");
+                    } else {
+                        if (d.getContainer() instanceof Declaration) {
+                            qualify(that.getPrimary(), (Declaration)d.getContainer());
+                        } else if (d.getContainer() instanceof Package) {
+                            out(names.moduleAlias(((Package)d.getContainer()).getModule()));
+                        }
                     }
-                }
-                out(names.name((TypeDeclaration)d.getContainer()), names.constructorSeparator(d),
-                        names.name(d), "()");
-                if (wrap) {
-                    out(";}");
+                    if (cnst.getTypescriptEnum() != null) {
+                        out(names.name((TypeDeclaration)d.getContainer()), ".", cnst.getTypescriptEnum());
+                    } else {
+                        out(names.name((TypeDeclaration)d.getContainer()), names.constructorSeparator(d),
+                            names.name(d), "()");
+                    }
+                    if (wrap) {
+                        out(";}");
+                    }
                 }
             } else if (d instanceof Function) {
                 Function fd = (Function)d;

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
@@ -9,6 +9,7 @@ import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_DS_VAR
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_DYNAMIC;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_FLAGS;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_INTERFACES;
+import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_JS_TSENUM;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_METATYPE;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_METHODS;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_MODULE;
@@ -309,6 +310,9 @@ public class JsonPackage extends LazyPackage {
                     cf.setDeprecated(cnst.isDeprecated());
                     cf.setDynamic(cnst.isDynamic());
                     cls.addMember(cf);
+                }
+                if (cons.getValue().containsKey(KEY_JS_TSENUM)) {
+                    cnst.setTypescriptEnum((String)cons.getValue().get(KEY_JS_TSENUM));
                 }
             }
         } else {

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/MetamodelGenerator.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/MetamodelGenerator.java
@@ -66,6 +66,7 @@ public class MetamodelGenerator {
     public static final String KEY_DYNAMIC      = "dyn";
 
     // backend specific keys
+    public static final String KEY_JS_TSENUM    = "$tsenum"; // case constructor is a TypeScript enum
 
     public static final String METATYPE_CLASS           = "c";
     public static final String METATYPE_INTERFACE       = "i";

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/MetamodelGenerator.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/MetamodelGenerator.java
@@ -66,7 +66,6 @@ public class MetamodelGenerator {
     public static final String KEY_DYNAMIC      = "dyn";
 
     // backend specific keys
-    public static final String KEY_JS_NEW       = "$new"; // should be instantiated with new; TypeScript interop
 
     public static final String METATYPE_CLASS           = "c";
     public static final String METATYPE_INTERFACE       = "i";

--- a/language/runtime-js/dynamic_functions.js
+++ b/language/runtime-js/dynamic_functions.js
@@ -11,6 +11,14 @@ function dre$$(object, type, loc) {
   if (typeof(object)==='object' && Object.isFrozen(object)) {
     throw new Error("Cannot add Ceylon type information to a frozen object");
   }
+  //If it's a TypeScript enum, accept number values and nothing else
+  if (type.t.$$.$tsenum) {
+    if (typeof(object)==='number') {
+      return undefined;
+    } else {
+      throw new Error("Native object cannot be a TypeScript enum");
+    }
+  }
   function memberTypeIsDynamicInterface$(t) {
     if (t.t && t.t.dynmem$) {
       return t;

--- a/language/runtime-js/is-op.js
+++ b/language/runtime-js/is-op.js
@@ -6,6 +6,8 @@ function is$(obj,type,containers){
       return obj===finished();
     } else if (type.t===$_String && typeof(obj)==='string') {
       return true;
+    } else if (type.t.$$ && type.t.$$.$tsenum) {
+      return typeof(obj) === 'number';
     }
     if(obj===null||obj===undefined){
       return type.t===Null||type.t===Anything;

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Constructor.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Constructor.java
@@ -24,6 +24,8 @@ public class Constructor extends TypeDeclaration implements Functional {
     private List<Declaration> members = new ArrayList<Declaration>(3);
     private List<Annotation> annotations = new ArrayList<Annotation>(4);
     
+    private String typescriptEnum = null;
+    
     public boolean isValueConstructor() {
         return parameterList==null;
     }
@@ -120,6 +122,44 @@ public class Constructor extends TypeDeclaration implements Functional {
             }
         }
         return null;
+    }
+    
+    /**
+     * Whether this constructor corresponds to a TypeScript enum.
+     *
+     * @return
+     * <ul>
+     *   <li>{@code null} if this constructor does not correspond to a TypeScript enum.</li>
+     *   <li>A numerical string if this constructor corresponds to a {@code const} TypeScript enum.</li>
+     *   <li>An identifier string if this constructor corresponds to a non-{@code const} TypeScript enum.</li>
+     * </ul>
+     */
+    public String getTypescriptEnum() {
+        return typescriptEnum;
+    }
+    
+    /**
+     * @see #getTypescriptEnum
+     * @throws IllegalStateException if this is not a value constructor.
+     * @throws IllegalArgumentException if the argument is neither numeric nor a legal JavaScript identifier.
+     */
+    public void setTypescriptEnum(String val) {
+        if (val != null) {
+            if (!isValueConstructor())
+                throw new IllegalStateException("Only value constructors can be TypeScript enums");
+            if (!val.matches("[0-9.-]+") && !val.matches("[\\p{L}\\{Nl}$_][\\p{L}\\p{Nl}$_\u200C\u200D\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}]*")) {
+                StringBuilder message = new StringBuilder("Illegal TypeScript enum name or value '");
+                message.append(val);
+                message.append("'");
+                if (isMember()) {
+                    message.append(" for member of '");
+                    message.append(((ClassOrInterface)getContainer()).getName());
+                    message.append("'");
+                }
+                throw new IllegalArgumentException(message.toString());
+            }
+        }
+        typescriptEnum = val;
     }
     
     @Override


### PR DESCRIPTION
TypeScript enums are distinguished by a `$tsenum` field; the compiler can generate code to properly access them, and `dre$$` and `is$` accept number values for these types.

Putting this up for review in case anyone wants to look at it. Otherwise I’ll probably just merge it in a few weeks or so.
