### PR TITLE
Gradle build: Import OsgiVersion from model into buildSrc 

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,3 +7,28 @@ repositories {
 dependencies {
 }
 
+ext {
+    modelSrc = "${rootProject.projectDir}/../model/src/com/redhat/ceylon/model/loader"
+    modelDest = "${buildDir}/copiedSrc"
+}
+
+task copySrc(type : Copy) {
+    from modelSrc, {
+        include 'OsgiVersion.java'
+    }
+    into modelDest
+}
+
+compileGroovy.dependsOn copySrc
+
+sourceSets {
+    main {
+        groovy {
+            srcDir modelDest
+        }
+    }
+}
+
+assemble.doFirst {
+    println "***** ${rootProject.projectDir}"
+}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -28,7 +28,3 @@ sourceSets {
         }
     }
 }
-
-assemble.doFirst {
-    println "***** ${rootProject.projectDir}"
-}

--- a/buildSrc/src/main/groovy/com/redhat/ceylon/common/log/Logger.groovy
+++ b/buildSrc/src/main/groovy/com/redhat/ceylon/common/log/Logger.groovy
@@ -1,0 +1,11 @@
+package com.redhat.ceylon.common.log
+
+import groovy.transform.CompileStatic
+
+
+@CompileStatic
+class Logger {
+    void error(Object... args) {
+
+    }
+}


### PR DESCRIPTION
Import OsgiVersion from model into buildSrc so that the functionality… becomes available to Gradle at build time
