### PR TITLE
Gradle build:

### DIFF
--- a/ant-plugin/antplugin.gradle
+++ b/ant-plugin/antplugin.gradle
@@ -6,6 +6,7 @@ targetCompatibility = cbp.'compile.java.target'
 
 dependencies {
     compile project(':cli')
+    compileOnly project(':common')
     compile antDep
     testCompile junitDep
 }
@@ -13,16 +14,13 @@ dependencies {
 sourceSets {
     main {
         java {
-            srcDirs = [ "${project(':compiler-java').projectDir}/src","${project(':common').projectDir}/src"]
+            srcDirs = [ "${project(':compiler-java').projectDir}/src"]
             include 'com/redhat/ceylon/ant/**'
-            include 'com/redhat/ceylon/common/**'
             include 'com/redhat/ceylon/launcher/**'
-            exclude 'com/redhat/ceylon/common/log/**'
         }
         resources {
-            srcDirs = [ "${project(':compiler-java').projectDir}/src","${project(':common').projectDir}/src"]
+            srcDirs = [ "${project(':compiler-java').projectDir}/src"]
             include "com/redhat/ceylon/ant/antlib.xml"
-            include "com/redhat/ceylon/common/config/messages.properties"
         }
     }
 }
@@ -30,6 +28,12 @@ sourceSets {
 jar {
     description 'Create Ant tasks jar'
     archiveName = 'ceylon-ant.jar'
+
+    from ({zipTree(project(':common').configurations.default.allArtifacts.files.singleFile)}) {
+            include 'com/redhat/ceylon/common/**'
+            exclude 'com/redhat/ceylon/common/log/**'
+            exclude 'com/redhat/ceylon/common/resources/**'
+    }
 }
 
 task publishInternal( type : Copy ) {

--- a/gradle/linked-projects/linked-project.gradle
+++ b/gradle/linked-projects/linked-project.gradle
@@ -77,9 +77,10 @@ task status {
 
 clean {
     delete = []
-//    delete localRepoBuildDir
 
-    dependsOn 'cleanAntBuild'
+    if (localRepoFolder.exists()) {
+        dependsOn 'cleanAntBuild'
+    }
 }
 
 

--- a/runtime-externals/task-generator.gradle
+++ b/runtime-externals/task-generator.gradle
@@ -1,5 +1,7 @@
 apply plugin : CeylonBuildOsgiPlugin
 
+tasks.remove(tasks.moduleXml)
+
 ext.createTasksFor = { File baseFile,File jarFile, File depsDestination, Task checksum, Task parentLifecycleTask ->
     String taskNamePostfix = jarFile.name[0..-5]
     String relativePath = CeylonBuildUtil.relativeTo(jarFile.parentFile.absoluteFile,baseFile)

--- a/settings.gradle
+++ b/settings.gradle
@@ -67,11 +67,9 @@ project(':typechecker').buildFileName = 'typechecker.gradle'
 // Linked projects
 // ----------------------------------------------------------------------------
 // ,'ideEclipse', 'ideIntellij'
-/*
 ['sdk','formatter','toolConverterJava2ceylon','ideCommon','ideEclipse'].each { proj ->
     String projName = "linked:${proj}"
     include(projName)
     project(':'+projName).projectDir = file("gradle/linked-projects")
     project(':'+projName).buildFileName = "${proj}.gradle"
 }
-*/


### PR DESCRIPTION
- Enabled linked-projects (Expecting some still to fail).
- FIxed cleaning issue for linked projects
- Build Ant plugin without rebuilding `common`.
