### PR TITLE
persist ClassAlias constructors in JSON model

### DIFF
--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/JsonPackage.java
@@ -3,6 +3,7 @@ package com.redhat.ceylon.compiler.js.loader;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_ANNOTATIONS;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_ATTRIBUTES;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_CLASSES;
+import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_CONSTRUCTOR;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_CONSTRUCTORS;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_DEFAULT;
 import static com.redhat.ceylon.compiler.js.loader.MetamodelGenerator.KEY_DS_VARIANCE;
@@ -49,6 +50,7 @@ import com.redhat.ceylon.common.Backend;
 import com.redhat.ceylon.common.Backends;
 import com.redhat.ceylon.compiler.js.CompilerErrorException;
 import com.redhat.ceylon.model.typechecker.model.Annotation;
+import com.redhat.ceylon.model.typechecker.model.ClassAlias;
 import com.redhat.ceylon.model.typechecker.model.ClassOrInterface;
 import com.redhat.ceylon.model.typechecker.model.Constructor;
 import com.redhat.ceylon.model.typechecker.model.Declaration;
@@ -262,6 +264,17 @@ public class JsonPackage extends LazyPackage {
             }
         }
 
+        if (cls instanceof ClassAlias) {
+            ClassAlias ca = (ClassAlias) cls;
+            if (m.containsKey(KEY_CONSTRUCTOR)) {
+                String constructorName = (String) m.get(KEY_CONSTRUCTOR);
+                Function ctorFn = (Function) ca.getExtendedType().getDeclaration().getDirectMember(constructorName, null, false);
+                ca.setConstructor(ctorFn.getType().getDeclaration());
+            }
+            else {
+                ca.setConstructor(ca.getExtendedType().getDeclaration());
+            }
+        }
         if (m.containsKey(KEY_CONSTRUCTORS)) {
             final Map<String,Map<String,Object>> constructors = (Map<String,Map<String,Object>>)m.remove(
                     KEY_CONSTRUCTORS);

--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/MetamodelGenerator.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/loader/MetamodelGenerator.java
@@ -13,6 +13,7 @@ import com.redhat.ceylon.common.Backend;
 import com.redhat.ceylon.common.Versions;
 import com.redhat.ceylon.compiler.js.util.TypeUtils;
 import com.redhat.ceylon.model.typechecker.model.Annotation;
+import com.redhat.ceylon.model.typechecker.model.ClassAlias;
 import com.redhat.ceylon.model.typechecker.model.Constructor;
 import com.redhat.ceylon.model.typechecker.model.Declaration;
 import com.redhat.ceylon.model.typechecker.model.DeclarationKind;
@@ -59,6 +60,7 @@ public class MetamodelGenerator {
     public static final String KEY_SATISFIES    = "sts";
     public static final String KEY_DS_VARIANCE  = "dv"; //declaration-site variance
     public static final String KEY_US_VARIANCE  = "uv"; //use-site variance
+    public static final String KEY_CONSTRUCTOR  = "co";
     public static final String KEY_CONSTRUCTORS = "$cn";
     public static final String KEY_FLAGS        = "$ff";
 
@@ -480,6 +482,11 @@ public class MetamodelGenerator {
         }
         if (d.isAlias()) {
             m.put("$alias", 1);
+            TypeDeclaration constructor = ((ClassAlias)d).getConstructor();
+            if (constructor instanceof Constructor) {
+                m.put(KEY_CONSTRUCTOR, ((Constructor)constructor).getName());
+            }
+            // else, it's the default "constructor", and will be the (Class) d.getExtendedType().getDeclaration()
         }
         Map<String, Object> parent = findParent(d);
         if (parent != null) {


### PR DESCRIPTION
`ClassAlias.getConstructor()` was returning null. See also https://github.com/jvasileff/ceylon-dart/issues/32.

Apparently the JS backend doesn't need this info to instantiate class aliases (I guess class aliases exist in the generated code as functions?), but perhaps they are needed for the metamodel in some way.

This does fix an issue for the Dart backend, where top-level class aliases are not reified in any way.
