### PR TITLE
optimize & refine return types for  Sequential.span() & measure()

### DIFF
--- a/language/src/ceylon/language/Sequence.ceylon
+++ b/language/src/ceylon/language/Sequence.ceylon
@@ -190,44 +190,32 @@ shared sealed interface Sequence<out Element=Anything>
     shared actual default 
     Element[] span(Integer from, Integer to) {
         if (from <= to) {
-            return 
-                if (to >= 0 && from <= lastIndex) 
-                then ArraySequence(Array(sublist(from,to)))
-                else [];
+            return
+                if (to < 0 || from > lastIndex)
+                    then []
+                else if (from <= 0 && to >= lastIndex)
+                    then this
+                else
+                    ArraySequence(Array(sublist(from, to)));
         }
         else {
-            return 
-                if (from >= 0 && to <= lastIndex) 
-                then ArraySequence(Array(sublist(to,from).reversed))
-                else [];
+            return
+                if (from < 0 || to > lastIndex)
+                    then []
+                else if (to <= 0 && from >= lastIndex)
+                    then reversed
+                else
+                    ArraySequence(Array(sublist(to, from).reversed));
         }
     }
     
     shared actual default 
-    Element[] spanFrom(Integer from) {
-        if (from <= 0) {
-            return this;
-        }
-        else if (from < size) {
-            return ArraySequence(Array(sublistFrom(from)));
-        }
-        else {
-            return [];
-        }
-    }
+    Element[] spanFrom(Integer from)
+            => span(from, size);
     
     shared actual default 
-    Element[] spanTo(Integer to) {
-        if (to >= lastIndex) {
-            return this;
-        }
-        else if (to >= 0) {
-            return ArraySequence(Array(sublistTo(to)));
-        }
-        else {
-            return [];
-        }
-    }
+    Element[] spanTo(Integer to)
+            => span(-1, to);
     
     shared actual default 
     String string => (super of Sequential<Element>).string;

--- a/language/src/ceylon/language/Sequential.ceylon
+++ b/language/src/ceylon/language/Sequential.ceylon
@@ -160,4 +160,15 @@ shared interface Sequential<out Element=Anything>
     String string 
             => empty then "[]" else "[``commaList(this)``]";
     
+    shared actual formal 
+    Element[] measure(Integer from, Integer length);
+
+    shared actual formal 
+    Element[] span(Integer from, Integer to);
+
+    shared actual formal
+    Element[] spanFrom(Integer from);
+
+    shared actual formal
+    Element[] spanTo(Integer to);
 }


### PR DESCRIPTION
1. `Sequence.span()` now optimizes away array copies when possible, returning `this` or `reversed`
2. `Sequential` `span` and `measure` returned `List`s before, and now return `Sequential`s.

I'm not 100% sure about compatibility for the second item.

Although it probably won't cause many source code breakages, is it BC? I think yes, since `List` still has refinements that return `List`s, but I could be missing something.
