### PR TITLE
Remove outdated reference to Ceylon 1.0

### DIFF
--- a/typechecker/en/modules/modules.xml
+++ b/typechecker/en/modules/modules.xml
@@ -645,7 +645,7 @@ shared package org.hibernate.query;</programlisting>
             repository system such as Maven. This specification does not define the 
             semantics of this identifier.</para>
             
-            <comment><para>Note: in Ceylon 1.0 it is illegal to explicitly import the
+            <comment><para>Note: currently, it is illegal to explicitly import the
             module <literal>ceylon.language</literal>. The language module is always
             implicitly imported.</para></comment>
             


### PR DESCRIPTION
---

There’s also some references to `ceylon.language-1.0.1`, but I think we can leave those… no point trying to keep those updated with each release, right?