### PR TITLE
Fix #6952: ceylondoc syntax highlighter breaks on '"'

### DIFF
--- a/compiler-java/src/com/redhat/ceylon/ceylondoc/resources/ceylon.js
+++ b/compiler-java/src/com/redhat/ceylon/ceylondoc/resources/ceylon.js
@@ -21,12 +21,12 @@ Rainbow.extend( "ceylon", [
     pattern: /\b(assembly|module|package|import|alias|class|interface|object|given|value|assign|void|function|new|of|extends|satisfies|abstracts|in|out|return|break|continue|throw|assert|dynamic|if|else|switch|case|for|while|try|catch|finally|then|let|this|outer|super|is|exists|nonempty|while)\b/g
   },
   {
-    name: "string",
-    pattern: /"""([^"]|"[^"]|""[^"])*"""|(``|")([^"\\`]|\\.|`[^`"])*(`"|``|")/gm
-  },
-  {
     name: "char",
     pattern: /'([^'\\\n]|\\.)*'/gm
+  },
+  {
+    name: "string",
+    pattern: /"""([^"]|"[^"]|""[^"])*"""|(``|(?:^|[^'])")([^"\\`]|\\.|`[^`"])*(`"|``|")/gm
   },
   {
     name: "constant.numeric",

--- a/typechecker/en/styles/ceylon.js
+++ b/typechecker/en/styles/ceylon.js
@@ -21,12 +21,12 @@ Rainbow.extend( "ceylon", [
     pattern: /\b(assembly|module|package|import|alias|class|interface|object|given|value|assign|void|function|new|of|extends|satisfies|abstracts|in|out|return|break|continue|throw|assert|dynamic|if|else|switch|case|for|while|try|catch|finally|then|let|this|outer|super|is|exists|nonempty|while)\b/g
   },
   {
-    name: "string",
-    pattern: /"""([^"]|"[^"]|""[^"])*"""|(``|")([^"\\`]|\\.|`[^`"])*(`"|``|")/gm
-  },
-  {
     name: "char",
     pattern: /'([^'\\\n]|\\.)*'/gm
+  },
+  {
+    name: "string",
+    pattern: /"""([^"]|"[^"]|""[^"])*"""|(``|(?:^|[^'])")([^"\\`]|\\.|`[^`"])*(`"|``|")/gm
   },
   {
     name: "constant.numeric",


### PR DESCRIPTION
This moves the char rule before the string rule, and adds an assertion to the string rule that the character before the opening double quote is not a single quote. This does not fix all problematic situations – one example: `/* " */ ... /* " */` – but it’s enough to fix this bug, and I don’t think it should cause regressions in reasonable code.