### PR TITLE
Amended boolean operation precedence in ConstantIterable.getEmtpy

### DIFF
--- a/language/runtime/com/redhat/ceylon/compiler/java/language/ConstantIterable.java
+++ b/language/runtime/com/redhat/ceylon/compiler/java/language/ConstantIterable.java
@@ -58,8 +58,8 @@ public final class ConstantIterable<Element, Absent>
     
     @Override
     public boolean getEmpty() {
-        return initial == null || initial.length == 0
-                && rest == null || rest.getEmpty();
+        return (initial == null || initial.length == 0)
+                && (rest == null || rest.getEmpty());
     }
     
     @Override


### PR DESCRIPTION
Precedence in 
```
initial == null || initial.length == 0 && rest == null || rest.getEmpty()
```
is not OK, as && have higher precedence than ||.
This causes a NPE when `rest==null`.
Easy to fix, just add parenthesis.