### PR TITLE
Remove unneeded & incomplete check for ambiguous member

### DIFF
--- a/model/src/com/redhat/ceylon/model/typechecker/model/Type.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Type.java
@@ -1685,8 +1685,8 @@ public class Type extends Reference {
                     .getDeclaration();
         List<TypeDeclaration> allSupertypes =
                 td.getSupertypeDeclarations();
-        List<ClassOrInterface> supertypes =
-                new ArrayList<>(allSupertypes.size());
+        List<ClassOrInterface> supertypes = null;
+        ClassOrInterface firstCandidate = null;
         for (TypeDeclaration std: allSupertypes) {
             if (std instanceof ClassOrInterface
                     && c.satisfies(std)) {
@@ -1698,10 +1698,26 @@ public class Type extends Reference {
                     }
                 }
                 if (allInherit) {
-                    supertypes.add((ClassOrInterface)std);
+                    if (supertypes == null && firstCandidate == null) {
+                        firstCandidate = (ClassOrInterface)std;
+                    } else if (supertypes == null) {
+                        supertypes = new ArrayList<>(
+                                allSupertypes.size());
+                        supertypes.add(firstCandidate);
+                        firstCandidate = null;
+                        supertypes.add((ClassOrInterface)std);
+                    } else {
+                        supertypes.add((ClassOrInterface)std);
+                    }
                 }
             }
         }
+
+        //optimized 0 and 1 candidate cases
+        if (supertypes == null) {
+            return firstCandidate;
+        }
+
         List<ClassOrInterface> ambiguousCases =
                 new ArrayList<>(supertypes.size());
         while (!supertypes.isEmpty()) {

--- a/model/src/com/redhat/ceylon/model/typechecker/model/Type.java
+++ b/model/src/com/redhat/ceylon/model/typechecker/model/Type.java
@@ -1683,58 +1683,59 @@ public class Type extends Reference {
         TypeDeclaration td = 
                 types.get(0)
                     .getDeclaration();
-        List<TypeDeclaration> results
-            = new LinkedList<TypeDeclaration>();
-        for (TypeDeclaration std: 
-                td.getSupertypeDeclarations()) {
-            if (std instanceof ClassOrInterface && 
-                    c.satisfies(std)) {
+        List<TypeDeclaration> allSupertypes =
+                td.getSupertypeDeclarations();
+        List<ClassOrInterface> supertypes =
+                new ArrayList<>(allSupertypes.size());
+        for (TypeDeclaration std: allSupertypes) {
+            if (std instanceof ClassOrInterface
+                    && c.satisfies(std)) {
+                boolean allInherit = true;
                 for (Type ct: types) {
-                    if (!ct.getDeclaration()
-                            .inherits(std)) {
-                        std = null;
+                    if (!ct.getDeclaration().inherits(std)) {
+                        allInherit = false;
                         break;
                     }
                 }
-                if (std!=null) {
-                    if (results.isEmpty()) {
-                        results.add(std);
-                    }
-                    else {
-                        for (int i=results.size()-1; 
-                                i>=0; i--) {
-                            TypeDeclaration result = 
-                                    results.get(i);
-                            if (std.inherits(result)) {
-                                //first supertype 
-                                //encountered, so this 
-                                //is where it belongs 
-                                //in the chain
-                                results.add(i+1, std);
-                                break;
-                            }
-                            else if (result.inherits(std)) {
-                                //keep looking for a 
-                                //supertype further "up"
-                                //the chain, unless...
-                                if (i==0) {
-                                    results.add(0, std);
-                                }
-                            }
-                            else {
-                                //the two types are unrelated
-                                //by inheritance, we need to
-                                //try and find a common 
-                                //supertype
-                                results.remove(i);
-                            }
-                        }
-                    }
+                if (allInherit) {
+                    supertypes.add((ClassOrInterface)std);
                 }
             }
         }
-        return results.isEmpty() ? null : 
-            results.get(results.size()-1);
+        List<ClassOrInterface> ambiguousCases =
+                new ArrayList<>(supertypes.size());
+        while (!supertypes.isEmpty()) {
+            //bottom nodes (those not inherited by any other) are our
+            //best candidates, but if more than one, they are ambiguous
+            for (ClassOrInterface st : supertypes) {
+                boolean bottom = true;
+                for (ClassOrInterface other : supertypes) {
+                    if (!st.equals(other) && other.inherits(st)) {
+                        bottom = false;
+                        break;
+                    }
+                }
+                if (bottom) {
+                    ambiguousCases.add(st);
+                }
+            }
+            if (ambiguousCases.size() == 1) {
+                return ambiguousCases.get(0);
+            }
+            //more than one. prune declarations
+            //not inherited by all ambiguousCases
+            for (int i = 0; i < supertypes.size(); i++) {
+                for (ClassOrInterface ac : ambiguousCases) {
+                    if (!ac.inherits(supertypes.get(i))) {
+                        supertypes.remove(i);
+                        i -= 1;
+                        break;
+                    }
+                }
+            }
+            ambiguousCases.clear();
+        }
+        return null;
     }
     
     private static ThreadLocal<Integer> depth = 


### PR DESCRIPTION
@gavinking if you think this code is good, I can add the test, just let me know where.

TL;DR: the call `cd.foo()` in the middle of the code below should be allowed.

--------------

Presumably this check was in place to detect (and reject) unrelated or
sibling classes or interfaces that both define a member with a name that
we are looking for. But it does not account for:

1. The likelihood that the "unrelated" types inherit a common supertype that declares the member

2. The likelihood that whatever type inherits these types has already been proven to unambiguously inherit or override the member, and in any event, the member is ok to reference so long as we can find a common declaration for it.

Further, if a test for ambiguous inheritance of the member by the types
passed as arguments to this method *were* needed, the current test would
be incomplete, as it only considers *shared* inherited declarations: the
arguments to this method may be completely ambiguous WRT the criteria in
ways not detectable by this code.

-----------

Test code:

```ceylon
interface I { shared formal String foo(); }
interface J satisfies I { shared default actual String foo() => "foo"; }
interface K satisfies I { shared default actual String foo() => "foo"; }
interface L satisfies I { shared default actual String foo() => "foo"; }

class C() satisfies J & K { shared default actual String foo() => "foo"; }
class D() satisfies J & K { shared default actual String foo() => "foo"; }
class E() satisfies L & K { shared default actual String foo() => "foo"; }
class F() satisfies L     { }

C|D cd = C();
cd.foo(); // error but should be allowed (resolve to I.foo())

J|K jk = C();
jk.foo(); // allowed (resolves to I.foo())

C|E ce = C();
ce.foo(); // allowed (resolves to K.foo()), so why isn't cd.foo()!

C|F cf = C();
cf.foo(); // allowed (resolves to I.foo()), so why isn't cd.foo()!
```