### PR TITLE
Fix NativeAnnotation documentation

### DIFF
--- a/language/src/ceylon/language/annotations.ceylon
+++ b/language/src/ceylon/language/annotations.ceylon
@@ -233,8 +233,8 @@ shared annotation LateAnnotation late()
 "The annotation class for the [[native]] annotation."
 shared final sealed annotation class NativeAnnotation(backends)
         satisfies OptionalAnnotation<NativeAnnotation> {
-    "The compiler backend that this native annotation applies 
-     to, or the empty string to declare the annotated element 
+    "The compiler backend(s) that this native annotation applies 
+     to, or the empty sequence to declare the annotated element 
      is a native header."
     since("1.2.0")
     shared String* backends;


### PR DESCRIPTION
The annotation can hold more than one backend, and the empty string is not a legal value:

> error: illegal native backend name: '""' (must be either '"jvm"' or '"js"')

---

@gavinking is “empty sequence” okay? “empty sequential” sounds stupid to me.