### PR TITLE
Clarify package name rules

### DIFF
--- a/typechecker/en/modules/declarations.xml
+++ b/typechecker/en/modules/declarations.xml
@@ -118,7 +118,7 @@ TypeConstraints?
             <xref linkend="sourcelayout"/>.</para>
             
             <para>A package is a namespace. A full package name is a period-separated list of 
-            all-lowercase identifiers.</para>
+            initial lowercase identifiers.</para>
             
             <synopsis>FullPackageName: PackageName ("." PackageName)*</synopsis>
             


### PR DESCRIPTION
Neither the compilers nor the Herd module repository reject camelCase package names, so use the term “initial lowercase identifier” as in the rest of the specification.

---

I see two possible interpretations of the previous spec text, and I’m not sure which one is the intended one:

1. “all-lowercase identifiers” means “all `LIdentifiers`”, to prevent `packge.Name`. In this case, this commit is just a clarification.
2. “all-lowercase” means “each character in each identifier must be a `LowercaseCharacter`”, to prevent `packge.camelCaseName`. In this case, the spec and the implementation are in disagreement, and this commit changes the spec to align it with the implementation. (I’m afraid it’s probably too late to change the implementation, since I already pushed three camelCase modules to Herd ([1](https://herd.ceylon-lang.org/modules/de.lucaswerkmeister.ceylond.recordBased), [2](https://herd.ceylon-lang.org/modules/de.lucaswerkmeister.ceylond.packetBased), [3](https://herd.ceylon-lang.org/modules/de.lucaswerkmeister.ceylond.daemonizeProgram)) without realizing the spec prohibited it – sorry.)

@gavinking can you clear this up? If it’s the second case, then I probably need to update the commit message of this commit (possibly in the first case as well).