### PR TITLE
Parenthesize JS IIFEs

### DIFF
--- a/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/GenerateJsVisitor.java
+++ b/compiler-js/src/main/java/com/redhat/ceylon/compiler/js/GenerateJsVisitor.java
@@ -1205,7 +1205,7 @@ public class GenerateJsVisitor extends Visitor {
     @Override
     public void visit(final Tree.ObjectExpression that) {
         if (errVisitor.hasErrors(that))return;
-        out("function(){");
+        out("(function(){");
         try {
             final Tree.SatisfiedTypes sts = that.getSatisfiedTypes();
             final Tree.ExtendedType et = that.getExtendedType();
@@ -1215,7 +1215,7 @@ public class GenerateJsVisitor extends Visitor {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        out("}()");
+        out("}())");
     }
 
     @Override
@@ -2905,7 +2905,7 @@ public class GenerateJsVisitor extends Visitor {
     @Override
     public void visit(final Tree.ScaleOp that) {
         final String lhs = names.createTempVariable();
-        Operators.simpleBinaryOp(that, "function(){var "+lhs+"=", ";return ", ".scale("+lhs+");}()", this);
+        Operators.simpleBinaryOp(that, "(function(){var "+lhs+"=", ";return ", ".scale("+lhs+");}())", this);
     }
 
     @Override


### PR DESCRIPTION
Unparenthesized immediately invoked function expressions can in sometimes be mistaken for function statements and therefore result in parsing errors.

Fixes #7107.