### PR TITLE
Add Contextual.getOrElse(other)

### DIFF
--- a/language/src/ceylon/language/Contextual.ceylon
+++ b/language/src/ceylon/language/Contextual.ceylon
@@ -48,6 +48,10 @@ shared class Contextual<Element>() {
      exception if called when not within a try-resource block"
     native shared Element get();
     
+    "Returns the value previously set, or [[other]] if the value
+     is `null` or has not been set."
+    native shared Element? getOrElse(Element? other = null);
+    
     "Used to set a value for this `Contextual`"
     native shared class Using(Element|Element() newValue)
             satisfies Obtainable {
@@ -74,6 +78,13 @@ shared class Contextual<Element>() {
             assert (is Element null);
             return null;
         }
+    }
+    
+    native("jvm") shared Element? getOrElse(Element? other = null) {
+        if (exists result = threadLocal.get()) {
+            return result;
+        }
+        return other;
     }
     
     native("jvm") shared class Using(Element|Element() newValue)
@@ -113,6 +124,9 @@ shared class Contextual<Element>() {
             return null;
         }
     }
+    
+    native("js") shared Element? getOrElse(Element? other = null)
+        => val else other;
     
     native("js") shared class Using(Element|Element() newValue)
             satisfies Obtainable {

--- a/language/test/contextual.ceylon
+++ b/language/test/contextual.ceylon
@@ -1,7 +1,13 @@
 
 @test
 shared void testContextual() {
+    Boolean eq(Anything a, Anything b)
+        =>  if (exists a, exists b)
+            then a == b
+            else a exists == b exists;
+
     Contextual<String> stringValue = Contextual<String>();
+    Contextual<String?> optStringValue = Contextual<String?>();
     Contextual<Integer> intValue = Contextual<Integer>();
     try (stringValue.Using("a"), intValue.Using(1)) {
         check(stringValue.get()=="a", "contextual string");
@@ -11,4 +17,16 @@ shared void testContextual() {
         }
         check(intValue.get()==1, "contextual integer after");
     }
+    try (optStringValue.Using(null)) {
+        check(!optStringValue.get() exists, "contextual optional string null #1");
+    }
+    // Note: Contextuals can't distinguish between null and not-set!
+    check(!optStringValue.get() exists, "contextual optional string null #2");
+
+    check(eq(stringValue.getOrElse("other"), "other"), "contextual getOrElse #1");
+    check(eq(optStringValue.getOrElse("other"), "other"), "contextual getOrElse #2");
+
+    check(!stringValue.getOrElse(null) exists, "contextual getOrElse #3");
+    check(!optStringValue.getOrElse(null) exists, "contextual getOrElse #4");
 }
+


### PR DESCRIPTION
For review.

This adds a method `Element? Contextual.getOrElse(Element? other = null)` to [`Contextual`](https://modules.ceylon-lang.org/repo/1/ceylon/language/1.3.2/module-doc/api/Contextual.type.html) so that `Contextual`s may be queried when possibly not set.

A particular use case is for obtaining API credentials, where a `Contextual` may be one of several possible sources. An example of such an approach is AWS's [`DefaultAWSCredentialsProviderChain`](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html).

I don't think there is a clear "best" new api for this, so feedback is welcome. A few considerations & alternatives:

- `Boolean set => ...` (or `available`?)
- I chose not to have `getOrElse` be generic so that the default arg `null` could be provided to support `myContextual.getOrElse()`. This probably isn't best, but I'll wait for feedback before changing.
- We could use the name `getOrDefault`, to match [`Map.getOrDefault()`](https://modules.ceylon-lang.org/repo/1/ceylon/language/1.3.2/module-doc/api/Map.type.html#getOrDefault)
