### PR TITLE
use https instead of http for the font reference

### DIFF
--- a/typechecker/build.xml
+++ b/typechecker/build.xml
@@ -218,7 +218,7 @@
           <replacetoken><![CDATA[<link rel="stylesheet" href="../shared/css/html.css" type="text/css">]]></replacetoken>
           <replacevalue><![CDATA[<link rel="stylesheet" href="../shared/css/html.css" type="text/css">
 <link type='text/css' href='../shared/css/ceylon.css' rel='stylesheet'/>
-<link type='text/css' href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet'/>
+<link type='text/css' href='https://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet'/>
 <script src='../shared/css/rainbow.min.js' type='text/javascript'></script>
 <script src='../shared/css/ceylon.js' type='text/javascript'></script>
 <script src='../shared/css/bnf.js' type='text/javascript'></script>]]></replacevalue>
@@ -263,7 +263,7 @@
             <replacetoken><![CDATA[<link rel="stylesheet" href="../shared/css/html.css" type="text/css">]]></replacetoken>
             <replacevalue><![CDATA[<link rel="stylesheet" href="../shared/css/html.css" type="text/css">
   <link type='text/css' href='../shared/css/ceylon.css' rel='stylesheet'/>
-  <link type='text/css' href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet'/>
+  <link type='text/css' href='https://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet'/>
   <script src='../shared/css/rainbow.min.js' type='text/javascript'></script>
   <script src='../shared/css/ceylon.js' type='text/javascript'></script>
   <script src='../shared/css/bnf.js' type='text/javascript'></script>]]></replacevalue>


### PR DESCRIPTION
In several browsers (e.g. Chromium and Opera at my Ubuntu system), style sheets with `http:` URLs referenced from `https:` pages are not used. The page is still readable, but doesn't use the font which is meant to be used.
The same style sheet file is available with `https`.

This affects https://www.ceylon-lang.org/documentation/current/spec/html_single/ and also https://www.ceylon-lang.org/documentation/current/spec/html/ (and the pages linked from it).