### PR TITLE
Fix performance for List.equals for non-array based lists

### DIFF
--- a/language/src/ceylon/language/List.ceylon
+++ b/language/src/ceylon/language/List.ceylon
@@ -195,29 +195,29 @@ shared interface List<out Element=Anything>
         if (is String that) {
             return false;
         }
-        if (is List<> that, that.size==size) {
-            for (index in 0:size) {
-                value thisElement 
-                        = getFromFirst(index);
-                value thatElement 
-                        = that.getFromFirst(index);
+        else if (is List<> that) {
+            variable value size = this.size;
+            if (that.size != size) {
+                return false;
+            }
+            value thisIterator = this.iterator();
+            value thatIterator = that.iterator();
+            while (size-- > 0) {
+                value thisElement = thisIterator.next();
+                value thatElement = thatIterator.next();
                 if (exists thisElement) {
-                    if (exists thatElement) {
-                        if (thisElement!=thatElement) {
-                            return false;
-                        }
+                    if (!exists thatElement) {
+                        return false;
                     }
-                    else {
+                    else if (thisElement != thatElement) {
                         return false;
                     }
                 }
-                else if (exists thatElement) {
+                else if (thatElement exists) {
                     return false;
                 }
             }
-            else {
-                return true;
-            }
+            return true; 
         }
         else {
             return false;


### PR DESCRIPTION
This patch uses `Iterators` in `List.equals()` rather than accessing elements by index. Accessing elements by index has unacceptable performance characteristics for non-array based lists.

In benchmarks for *array* based lists, this patch performed similarly to the old code, sometimes a bit faster, and sometimes slower, but when slower, not by a significant amount in absolute terms (i.e. some tests completed in 200% more time, but with low nanosecond differences.)

In benchmarks for linked lists, this patch performed significantly better than the old code, as expected, and makes possible passing large lists to `equals()`. For all `List`s, `equals()` is now O(n).

------------

The following code (and variations of it) were used for testing on Ceylon 1.3.2:

```ceylon
import com.vasileff.ceylon.util.benchmark {
    benchmark
}
import ceylon.collection {
    LinkedList
}

shared void run() {
    for (size in (2..30).by(2)) {
        runBench(size * 1k);
    }
}

void runBench(Integer size) {
    print("\n\n--------- ``size`` ---------");
    value strings = (0:size).map((i) => i.string.pad(6));

    value linkedList1 = LinkedList(strings);
    value linkedList2 = LinkedList(strings);
    value array1 = Array(strings);
    value array2 = Array(strings);

    benchmark {
        veryQuiet = true;
        iterations = if (size == 0) then 1 else 200k/size;

        "array1 == linkedList1" -> (()=>array1 == linkedList1),
        "equalLists(array1, linkedList1)" -> (()=>equalLists(array1, linkedList1)),

        "array1 == array2" -> (()=>array1 == array2),
        "equalLists(array1, array2)" -> (()=>equalLists(array1, array2))
    };
}

Boolean equalLists(List<Anything> firstList, List<Anything> secondList) {
    variable value size = firstList.size;
    if (secondList.size != size) {
        return false;
    }
    value firstIterator = firstList.iterator();
    value secondIterator = secondList.iterator();
    while (size-- > 0) {
        value first = firstIterator.next();
        value second = secondIterator.next();
        if (exists first) {
            if (!exists second) {
                return false;
            }
            else if (first != second) {
                return false;
            }
        }
        else if (second exists) {
            return false;
        }
    }
    return true;
}
```

The following graph shows timings for `array1 == linkedList1` and `equalLists(array1, linkedList1)`:

<img width="536" alt="screen shot 2017-07-10 at 10 55 42 pm" src="https://user-images.githubusercontent.com/236050/28049674-cb1ef560-65c6-11e7-834f-6990b339ec42.png">

This shows the old O(n^2) performance for linked lists. The scale of the y-axis is not suitable for the timings for the new `equalLists(array1, linkedList1)`, but for the 30k element test, total time was under 0.4ms.

The next graph shows timings for array based lists. In this test, the new `equalLists()` outperformed the old code, but the differences are minor, and as noted before, other tests (with different list contents and parameters) showed an advantage for the old code.

<img width="517" alt="screen shot 2017-07-10 at 10 56 20 pm" src="https://user-images.githubusercontent.com/236050/28049772-7f093086-65c7-11e7-8f45-c9a923894e5f.png">

Raw numbers and additional graphs for these two tests are available at https://www.icloud.com/numbers/0RYHg83r5Q6aqeQOgm07q3ntQ#Ceylon_List.equals
