### PR TITLE
Sequence: Add "see Sequential" to docs

### DIFF
--- a/language/src/ceylon/language/Sequence.ceylon
+++ b/language/src/ceylon/language/Sequence.ceylon
@@ -36,6 +36,7 @@
  - [[Tuple]], a typed linked list, and
  - [[Singleton]], a sequence of just one element."
 see (interface Empty, 
+       interface Sequential,
        class ArraySequence, 
        class Range, 
        class Tuple, 


### PR DESCRIPTION
.. since when refreshing my knowledge about the Ceylon collection classes by reading the source I always get cut off from traversing Sequence → Sequential. Even the IDEs don't let me Control-click the superinterfaces.