### PR TITLE
French translation for the readme.md file

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -9,7 +9,8 @@ une syntaxe flexible et très lisible, un système de typage statique unique et 
 élégance hors du commun, une architecture de modules puissante et d'excellents outils,
 incluant entre autre un superbe IDE basé sur Eclipse.
 
-Ceylon permet le développement de modules multi-plateformes qui s'éxecute de manière
+Ceylon permet le développement de modules multi-plateformes qui s'exécutent de manière
+```
 portative dans les deux environements de machines virtuelles. Alternativement, un
 module de Ceylon peut cibler l'une ou l'autre plate-forme, auquel cas il peut 
 interopérer avec du code nativement écrit pour cette plate-forme.

--- a/README.fr.md
+++ b/README.fr.md
@@ -50,7 +50,7 @@ Le code source est disponible sur GitHub:
 
 ## Problèmes
 
-Des Bugs et suggestions peuvent être rapporté dans le suivi des problèmes de GitHub.
+Des Bugs et suggestions peuvent être rapportés dans le suivi des problèmes de GitHub.
 
 <http://github.com/ceylon/ceylon/issues>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -18,7 +18,7 @@ Pour en savoir plus sur Ceylon, rendez vous sur <http://ceylon-lang.org>.
 
 Pour lire ceci dans d'autres langues : [`English`](/README.md).
 
-## Disposition de la distribution
+## Composition de la distribution
 
 
 - `cmr`                 - *Ceylon Module Resolver* module

--- a/README.fr.md
+++ b/README.fr.md
@@ -54,7 +54,7 @@ Des Bugs et suggestions peuvent être rapportés dans le suivi des problèmes de
 
 <http://github.com/ceylon/ceylon/issues>
 
-## Systèmes sur lesquels Ceylon fonctionne
+## Systèmes sur lesquels Ceylon a été validé
 
 Puisque Ceylon fonctionne sur la JVM il devrait fonctionner sur toutes les plateformes
 qui supporte une JVM compatible avec Java 7 ou 8. Cependant, nous avons testé les plateformes

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,109 @@
+# Ceylon
+
+Ceci est la version 1.3.4-SNAPSHOT _"You'll Thank Me Later"_ de l'outil 
+de commande Ceylon. Il s'agit d'une version de production de la plateforme.
+
+Ceylon est un langage de programmation moderne, modulaire et statiquement typé. 
+pour les machines virtuelles Java et JavaScript. Le langage se caractérise par
+une syntaxe flexible et très lisible, un système de typage statique unique et d'une 
+élégance hors du commun, une architecture de modules puissante et d'excellents outils,
+incluant entre autre un superbe IDE basé sur Eclipse.
+
+Ceylon permet le développement de modules multi-plateformes qui s'éxecute de manière
+portative dans les deux environements de machines virtuelles. Alternativement, un
+module de Ceylon peut cibler l'une ou l'autre plate-forme, auquel cas il peut 
+interopérer avec du code nativement écrit pour cette plate-forme.
+
+Pour en savoir plus sur Ceylon, rendez vous sur <http://ceylon-lang.org>.
+
+## Disposition de la distribution
+
+
+- `cmr`                 - *Ceylon Module Resolver* module
+- `common`              - Common code module
+- `compiler-java`       - JVM compiler module
+- `compiler-js`         - JS compiler module
+- `dist`                - Build files 
+- `language`            - Ceylon language module
+- `model`               - Type model module
+- `runtime`             - Runtime module
+- `typechecker`         - Typechecker module
+- `langtools-classfile` - Java tools classfile module fork
+- `tool-provider`       - Ceylon tool provider module
+- `LICENSE-ASL` 	- La licence ASL de Ceylon
+- `LICENSE-GPL-CP` 	- La licence GPL/CP de Ceylon
+- `LICENSE-LGPL` 	- La licence LGPL de Ceylon
+- `README.md` 		- Ce fichier
+
+## Construire la distribution
+
+Allez dans le dossier `dist` et suivez les instructions dans le fichier [`BUILD.md`](/dist/BUILD.md) .
+
+## Code source
+
+Le code source est disponible sur GitHub:
+
+<http://github.com/ceylon>
+
+## Problèmes
+
+Des Bugs et suggestions peuvent être rapporté dans le suivi des problèmes de GitHub.
+
+<http://github.com/ceylon/ceylon/issues>
+
+## Systèmes sur lesquels Ceylon fonctionne
+
+Puisque Ceylon fonctionne sur la JVM il devrait fonctionner sur toutes les plates-formes
+qui supporte une JVM compatible avec Java 7 ou 8. Cependant, nous avons testé les plateformes
+suivantes pour nous assurer qu'elles fonctionnent :
+
+### Linux
+
+- Ubuntu "wily" 15.10 (64 bit) JDK 1.7.0_95 (IcedTea) Node 0.10.25
+- Fedora 23 (64 bit), JDK 1.8.0_77 (OpenJDK)
+- Fedora 22 (64 bit), JDK 1.8.0_72 (OpenJDK)
+- Fedora 22 (64 bit), JDK 1.7.0_71 (Oracle)
+
+### Windows
+
+- Windows 10 Home (64 bit) 1.8.0_77
+- Windows 7 (64 bit) 1.7.0_05 (Oracle)
+- Windows Server 2008 R2 SP1 JDK 1.7.0_04
+
+### OSX
+
+- OSX 10 Lion (10.8.5) JDK 1.7.0_40 (Oracle) Node 0.10.17
+- OSX 11 El Capitan (10.11.6) JDK 1.7.0_80 (Oracle) Node 0.10.35
+
+## License
+
+La distribution de Ceylon et le code qu'elle contient est :
+
+- en partie sous licence ASL v2.0 comme indiqué dans le fichier
+ `LICENSE-ASL` qui accompagnait ce code, et
+- en partie sous licence GPL v2 + Classpath Exception comme indiqué
+dans le fichier `LICENSE-GPL-CP` qui accompagnait ce code.
+
+### Termes de la licence pour les travaux d'un tiers
+
+Ce logiciel utilise un certain nombre d'autres travaux qui sont documentés
+dans le fichier `NOTICE` qui accompagne ce code.
+
+### Repository
+
+Le contenu de ce dépôt de code, [disponible ici sur GitHub][ceylon], 
+est publié sous licence ASL v2.0 comme indiqué dans le fichier `LICENSE-ASL` 
+qui accompagne ce code.
+
+[ceylon]: https://github.com/ceylon/ceylon
+
+En soumettant une "pull request" ou en contribuant d'une autre manière à ce
+dépot, vous acceptez que votre publication soit sous la licence mentionné
+ci-dessus.
+
+## Remerciements
+
+Nous sommes profondément redevables aux bénévoles de la communauté qui ont contribué à la réalisation de ce projet
+et à une partie substantielle de la base de code actuelle de Ceylon, travaillant souvent sur leur propre temps libre.
+
+Ceylon est un projet de la[Fondation Eclipse] (http://eclipse.org).

--- a/README.fr.md
+++ b/README.fr.md
@@ -3,7 +3,7 @@
 Ceci est la version 1.3.4-SNAPSHOT _"You'll Thank Me Later"_ de l'outil 
 de commande Ceylon. Il s'agit d'une version de production de la plateforme.
 
-Ceylon est un langage de programmation moderne, modulaire et statiquement typé. 
+Ceylon est un langage de programmation moderne, modulaire et statiquement typé,
 pour les machines virtuelles Java et JavaScript. Le langage se caractérise par
 une syntaxe flexible et très lisible, un système de typage statique unique et d'une 
 élégance hors du commun, une architecture de modules puissante et d'excellents outils,

--- a/README.fr.md
+++ b/README.fr.md
@@ -58,7 +58,7 @@ Des Bugs et suggestions peuvent être rapportés dans le suivi des problèmes de
 
 Puisque Ceylon fonctionne sur la JVM il devrait fonctionner sur toutes les plateformes
 qui supportent une JVM compatible avec Java 7 ou 8. Cependant, nous avons testé les plateformes
-suivantes pour nous assurer qu'elles fonctionnent :
+suivantes pour valider que Ceylon fonctionne correctement dessus :
 
 ### Linux
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -11,7 +11,7 @@ incluant entre autre un superbe IDE basé sur Eclipse.
 
 Ceylon permet le développement de modules multi-plateformes qui s'exécutent de manière
 ```
-portative dans les deux environements de machines virtuelles. Alternativement, un
+identique dans les deux environnements de machines virtuelles. Alternativement, un
 module de Ceylon peut cibler l'une ou l'autre plate-forme, auquel cas il peut 
 interopérer avec du code nativement écrit pour cette plate-forme.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -57,7 +57,7 @@ Des Bugs et suggestions peuvent être rapportés dans le suivi des problèmes de
 ## Systèmes sur lesquels Ceylon a été validé
 
 Puisque Ceylon fonctionne sur la JVM il devrait fonctionner sur toutes les plateformes
-qui supporte une JVM compatible avec Java 7 ou 8. Cependant, nous avons testé les plateformes
+qui supportent une JVM compatible avec Java 7 ou 8. Cependant, nous avons testé les plateformes
 suivantes pour nous assurer qu'elles fonctionnent :
 
 ### Linux

--- a/README.fr.md
+++ b/README.fr.md
@@ -16,6 +16,8 @@ interopérer avec du code nativement écrit pour cette plate-forme.
 
 Pour en savoir plus sur Ceylon, rendez vous sur <http://ceylon-lang.org>.
 
+Pour lire ceci dans d'autres langues : [`English`](/README.md).
+
 ## Disposition de la distribution
 
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -56,7 +56,7 @@ Des Bugs et suggestions peuvent être rapporté dans le suivi des problèmes de 
 
 ## Systèmes sur lesquels Ceylon fonctionne
 
-Puisque Ceylon fonctionne sur la JVM il devrait fonctionner sur toutes les plates-formes
+Puisque Ceylon fonctionne sur la JVM il devrait fonctionner sur toutes les plateformes
 qui supporte une JVM compatible avec Java 7 ou 8. Cependant, nous avons testé les plateformes
 suivantes pour nous assurer qu'elles fonctionnent :
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ it may interoperate with native code written for that platform.
 
 Read more about Ceylon at <http://ceylon-lang.org>.
 
+Read this in other languages: [`français`](/README.fr.md)
+
 ## Distribution layout
 
 - `cmr`                 - *Ceylon Module Resolver* module

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ it may interoperate with native code written for that platform.
 
 Read more about Ceylon at <http://ceylon-lang.org>.
 
-Read this in other languages: [`français`](/README.fr.md)
+Read this in other languages: [`français`](/README.fr.md).
 
 ## Distribution layout
 


### PR DESCRIPTION
Proposal of a french translation for the readme.md file. This translation can be accessed by a link in the original file to a new file named readme.fr.md.  